### PR TITLE
Phase 0 — foundation: leakage-free LSTM, package, infra, docs

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,21 @@
+# Copy to `.env` and fill in. `.env` is git-ignored. See src/market_intel/config.py.
+
+# --- Database (self-hosted Postgres + pgvector; see docker-compose.yml) ---
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=market_intel
+DB_USER=market_intel
+DB_PASSWORD=change_me
+
+# --- Redis ---
+REDIS_URL=redis://localhost:6379/0
+
+# --- Data source API keys (all optional in Phase 0; free tiers) ---
+# FRED_API_KEY=
+# FINNHUB_API_KEY=
+# TIINGO_API_KEY=
+# MARKETAUX_API_KEY=
+
+# --- Paths ---
+DATA_DIR=data
+MODELS_DIR=models

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,28 @@
 # Virtual environments
 .venv/
 venv/
+env/
+sklearn-env/
+.python-version
+
+# Secrets / local config
+.env
+.env.*
+!.env.example
+
+# Build / packaging
+build/
+dist/
+*.egg-info/
+
+# ML artifacts & data snapshots (root-anchored so they don't match src/market_intel/models/)
+/models/
+/mlruns/
+*.h5
+*.keras
+*.joblib
+*.pkl
+*.parquet
 
 # Python cache files
 __pycache__/

--- a/README.md
+++ b/README.md
@@ -1,14 +1,79 @@
-# Predict Stock Prices
+# Market Intelligence Terminal
 
-This project uses LSTM (Long Short-Term Memory) neural networks to predict stock prices based on historical data.
+A personal, Bloomberg-style global market-intelligence project. Today it does
+**leakage-free LSTM stock-price forecasting**; the roadmap grows it into a
+continuously-ingesting dashboard for news, economics, and markets worldwide.
 
-## Features
-- Fetch stock data using the `yfinance` library.
-- Preprocess and normalize data for model training.
-- Train an LSTM model using TensorFlow/Keras.
-- Visualize predictions against actual stock prices.
+> **Full vision & phased plan:** [docs/VISION_AND_ROADMAP.md](docs/VISION_AND_ROADMAP.md)
 
-## Installation
-1. Clone the repository:
-   ```bash
-   git clone <https://github.com/PatrickDann/predict-stock-prices.git>
+## Current features (Phase 0)
+
+- **Format-agnostic loader** for single- and multi-ticker yfinance CSVs.
+- **Leakage-free LSTM**: scaler fit on the train slice only, windows never cross
+  split boundaries, plus walk-forward (expanding-window) cross-validation.
+- Typed config (`pydantic-settings`), tests (`pytest`), linting (`ruff`/`black`).
+- Self-hosted data layer via `docker-compose` (Postgres + pgvector + Redis).
+
+## Project layout
+
+```
+src/market_intel/
+  config.py             # typed settings (.env)
+  data/loaders.py       # format-agnostic price CSV loader
+  data/fetch.py         # yfinance downloader
+  models/windowing.py   # leakage-free split + sequence construction
+  models/lstm.py        # model, train/evaluate, walk-forward CV
+src/multi_feature_model.py  # thin training CLI
+src/preprocess.py           # thin fetch CLI
+tests/                      # incl. the leakage regression test
+docker-compose.yml          # Postgres+pgvector + Redis
+docs/VISION_AND_ROADMAP.md  # the plan
+```
+
+## Setup
+
+```bash
+python3.12 -m venv .venv && source .venv/bin/activate
+pip install -r requirements.txt          # add -r requirements-dev.txt for tooling
+cp .env.example .env                      # then edit
+```
+
+## Usage
+
+```bash
+# Fetch price CSVs into data/
+python src/preprocess.py
+
+# Train a leakage-free LSTM and print honest RMSE/MAE
+python src/multi_feature_model.py AAPL
+
+# A ticker out of a multi-ticker file, with a saved chart
+python src/multi_feature_model.py MSFT --dataset tech --plot --plot-path out.png
+
+# Walk-forward cross-validation (the realistic score)
+python src/multi_feature_model.py AAPL --walk-forward 5
+```
+
+### Data layer (optional in Phase 0, required from Phase 1)
+
+```bash
+docker compose up -d        # Postgres+pgvector on 127.0.0.1:5432, Redis on 6379
+```
+
+Keep the DB bound to localhost / your Tailscale interface — never expose port 5432.
+
+## Development
+
+```bash
+pytest                      # run tests (incl. leakage regression)
+ruff check src tests
+black src tests
+```
+
+## A note on correctness
+
+The original model fit its scaler on the **entire** dataset and built sliding
+windows **before** splitting — both leak future information and make reported
+accuracy untrustworthy. This is fixed in `models/windowing.py` and locked in by
+`tests/test_windowing.py`. See the roadmap for why this was the highest-priority
+fix.

--- a/db/init/01_extensions.sql
+++ b/db/init/01_extensions.sql
@@ -1,0 +1,12 @@
+-- Runs once on first DB initialization (mounted into docker-entrypoint-initdb.d).
+-- Enables the extensions the project relies on. See docs/VISION_AND_ROADMAP.md §3.1.
+
+CREATE EXTENSION IF NOT EXISTS vector;   -- pgvector: embeddings / semantic news search
+
+-- pg_cron (in-DB scheduling for partition maintenance / rollups) is NOT in the
+-- pgvector/pgvector image. Add it in Phase 1 via an image that bundles it plus
+-- `shared_preload_libraries = 'pg_cron'`. Until then, APScheduler in the Python
+-- worker handles scheduling.
+--
+-- TimescaleDB is intentionally NOT used: time-series uses native range
+-- partitioning (BRIN now -> pg_partman later) + Parquet/DuckDB for ML history.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,43 @@
+# Self-hosted data layer for the market-intelligence terminal (see docs/VISION_AND_ROADMAP.md §3.1).
+# Plain Postgres + pgvector (NO TimescaleDB — native partitioning + DuckDB/Parquet instead) + Redis.
+#
+#   docker compose up -d
+#   psql postgresql://market_intel:change_me@localhost:5432/market_intel
+#
+# Keep this bound to localhost / your Tailscale interface — never expose 5432 publicly.
+
+services:
+  db:
+    image: pgvector/pgvector:pg17
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${DB_NAME:-market_intel}
+      POSTGRES_USER: ${DB_USER:-market_intel}
+      POSTGRES_PASSWORD: ${DB_PASSWORD:-change_me}
+    ports:
+      - "127.0.0.1:5432:5432" # localhost-only by design
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./db/init:/docker-entrypoint-initdb.d:ro # *.sql here run once on first init
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-market_intel} -d ${DB_NAME:-market_intel}"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    restart: unless-stopped
+    ports:
+      - "127.0.0.1:6379:6379"
+    volumes:
+      - redisdata:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+
+volumes:
+  pgdata:
+  redisdata:

--- a/docs/VISION_AND_ROADMAP.md
+++ b/docs/VISION_AND_ROADMAP.md
@@ -1,0 +1,269 @@
+# Global Market Intelligence Terminal — Vision & Roadmap
+
+> From a single-file LSTM stock-price demo to a personal, Bloomberg-style global
+> intelligence dashboard that ingests news, economics, and markets worldwide —
+> and feeds a clean, leakage-free ML forecasting layer.
+
+_Last updated: 2026-06-13. Research current as of mid-2026 — verify vendor pricing/limits before committing._
+
+---
+
+## 1. Where we are today (codebase review)
+
+The repo is an early-stage hobby project: **2 Python scripts + 3 CSVs, 8 tracked files.**
+
+```
+predict-stock-prices/
+├── requirements.txt          # ⚠️ missing the actual ML deps
+├── README.md                 # ⚠️ truncated mid-sentence
+├── .gitignore
+├── data/                     # 3 yfinance CSV dumps (tracked in git)
+│   ├── aapl_stock_data.csv         (single-ticker, wide)
+│   ├── tech_stock_data.csv         (multi-ticker, different shape)
+│   └── index_fund_stock_data.csv
+└── src/
+    ├── preprocess.py         # yfinance download → CSV
+    └── multi_feature_model.py# load CSV → LSTM → predict → matplotlib
+```
+
+### What works
+- A clean, readable end-to-end LSTM example: fetch → normalize → window → train → evaluate (RMSE) → plot.
+- Sensible model shape: 2× LSTM(50) + Dropout + Dense, multivariate input (Close/High/Low/Open/Volume), 60-step lookback.
+- Multi-ticker data already collected (tech + index funds).
+
+### Concrete issues found (fix these in Phase 0)
+
+| # | Severity | Issue | Location |
+|---|----------|-------|----------|
+| 1 | **High** | `requirements.txt` omits `tensorflow`, `scikit-learn`, `matplotlib`. A fresh `pip install -r requirements.txt` cannot run the model. | `requirements.txt` |
+| 2 | **High — ML correctness** | **Data leakage.** `MinMaxScaler` is fit on the *entire* dataset before the train/val/test split (`scaled_data = scaler.fit_transform(...)`), and `scaler_close` is also fit on the full series. Windows are also built over the full array *before* splitting, so windows near boundaries peek across them. This inflates reported RMSE — the model looks better than it is. | `multi_feature_model.py:24-44, 68-69` |
+| 3 | **Medium** | `preprocess.py` has **three `if __name__ == "__main__"` blocks**; Python runs all three in sequence. The third (index funds) call passes only 3 args to a 4-arg function → `TypeError` at the end of every run. | `preprocess.py:15-34` |
+| 4 | **Medium** | The CSV loader is hardcoded to the single-ticker format (`skiprows=2`, fixed column rename). It cannot parse `tech_stock_data.csv` / `index_fund_stock_data.csv` (multi-ticker wide format), so `multi_feature_model.py TECH` breaks. | `multi_feature_model.py:18-19` |
+| 5 | **Medium** | No validation split discipline beyond fixed slices; no walk-forward / `TimeSeriesSplit`; hyperparameters not isolated to train. | `multi_feature_model.py:39-44` |
+| 6 | **Low** | Everything in one script (data + model + viz). No package layout, no config, no secrets handling, no saved/versioned models, no tests. | `src/` |
+| 7 | **Low** | Growing time-series stored as CSVs tracked in git — fine now, won't scale. | `data/` |
+| 8 | **Low** | README truncated; no run instructions, no architecture doc. | `README.md` |
+
+> Repo hygiene note: `.venv` (1.6 GB) and `sklearn-env` (172 MB) live in the working tree and inflate it to ~1.9 GB. Neither is tracked (good), but only `.venv/`/`venv/` are in `.gitignore` — add `sklearn-env/` and standardize on **one** environment.
+
+---
+
+## 2. Where we want to be (the end goal)
+
+A **personal Bloomberg-style terminal** that:
+
+- **Ingests globally and continuously** — news (incl. obscure, non-English, edge-of-the-world events), macro/economic releases, equities/FX/crypto/commodities.
+- **Stores everything cleanly** in a queryable, ML-ready data layer.
+- **Displays a dense, dark, multi-panel UI** — live news feed, candlestick charts, economic indicators, a world map of events, and model forecasts.
+- **Runs a clean, leakage-free ML layer** (LSTM today; TFT/N-HiTS tomorrow) that *fuses* news sentiment + macro + price.
+- **Surfaces signals** — links a faint headline in a remote market to the assets it might move.
+
+### The gap, at a glance
+
+| Capability | Today | End goal |
+|---|---|---|
+| Data sources | 1 (yfinance CSV) | News + macro + multi-asset markets + social |
+| Ingestion | Manual script run | Scheduled, validated, continuous pipeline |
+| Storage | 3 CSVs in git | Postgres/TimescaleDB + Parquet + search/vector |
+| Coverage | US equities | Global, multilingual, real-time |
+| UI | matplotlib `plt.show()` | Live multi-panel web terminal |
+| ML rigor | Leaky single LSTM | Leakage-free, walk-forward, tracked, multi-model |
+| Predictions | Ad-hoc plot | Scheduled forecasts stored + displayed |
+| News→market link | None | Sentiment/entity fusion + event signals |
+
+---
+
+## 3. Recommended tech stack (researched, 2026)
+
+**Guiding principle:** stay *boring and Postgres-centric*. Almost every "scalable" tool (Kafka, Airflow, Feast, a vector-DB cluster) is overkill at Phase 1. The lean stack runs on a laptop or a ~$5–10/mo VPS and scales **additively** — you swap one layer at a time, never rewrite.
+
+### Phase-1 lean stack (laptop / one cheap VPS)
+
+| Layer | Pick | Why |
+|---|---|---|
+| **Market history (ML-grade)** | **Tiingo** (~$30/mo flat, adjusted EOD back to ~1962) + **yfinance** for prototyping only | Clean, adjusted, survivorship-aware series — the one paid line item worth it for ML |
+| **Real-time + streaming quotes** | **Finnhub free** (60 req/min, real-time US, WebSocket 50 symbols) | Best free real-time + websocket |
+| **Macro / economics** | **FRED API** (free) + **DBnomics** (free, aggregates World Bank/IMF/OECD/Eurostat) | Covers ~95% of macro needs for $0 |
+| **Global news / events** | **GDELT 2.0 DOC API + GKG** (free, 100+ languages, 15-min, redistribution allowed) + self-hosted **RSS via FreshRSS** | GDELT = unbeatable global breadth + the edge-of-world angle; RSS = near-real-time long tail |
+| **Ticker-level sentiment** | **Marketaux** or **Finnhub** (free tiers) | Native per-entity sentiment, no NLP needed |
+| **Social signal (optional)** | **Bluesky Jetstream** (free websocket) + **Reddit** (free) | On-the-ground early signals; X/Twitter API is cost-prohibitive in 2026 |
+| **Filings / fundamentals** | **SEC EDGAR API** (free, survivorship-bias-free) | Straight from source |
+| **Database (time-series + docs + vector)** | **Self-hosted Postgres + pgvector** (`pgvector/pgvector:pg17` in Docker) on hardware you own — **`pgvector` HNSW + `tsvector` FTS + JSONB**, time-series via **native partitioning** (BRIN now → `pg_partman`+`pg_cron` when large). _See §3.1._ | Genuinely **$0**, no row/storage caps, real concurrency (poller writes while dashboard reads), full extension freedom |
+| **ML/analytics layer** | **DuckDB over Parquet** snapshots (can `ATTACH` the Postgres DB directly) | In-process, fast feature engineering + training inputs; **archiving history to Parquet keeps the hot DB small** |
+| **Live push** | **FastAPI WebSockets/SSE** (Redis pub/sub for fan-out later) | Self-hosted, no managed realtime service needed |
+| **Backups + remote access** | Nightly `pg_dump -Fc` → **Cloudflare R2 / Backblaze B2** (free tiers); DB stays **LAN-only or on Tailscale** | Off-box disaster recovery; never expose port 5432 publicly |
+| **Orchestration** | **APScheduler** in the Python worker (heavy ingestion/ML); **pg_cron** for light in-DB jobs | Zero extra infra; poll on schedules |
+| **Data validation** | **Pandera** at ingest + pre-train | Lightweight DataFrame contracts; quarantine bad rows |
+| **Dataset versioning** | **DVC + dated Parquet snapshots** | Reproducible training sets without a feature store |
+| **Backend API** | **FastAPI** + WebSockets/SSE | Async, typed, live updates; *doubles as model-serving + dashboard backend* |
+| **Cache / async work** | **Redis** + **ARQ** | Async-native worker matching FastAPI |
+| **ML modeling** | **Darts** (LSTM baseline, swap to N-HiTS/TFT later) | One API for LSTM → N-HiTS → TFT |
+| **Experiment tracking** | **MLflow** (local) + model registry | Free, self-hosted |
+| **Sentiment NLP** | **FinBERT** (self-hosted); LLM only on top-N flagged stories | Cheap bulk scoring; LLM for nuance |
+| **UI** | **OpenBB Workspace (free) + FastAPI custom backend** *or* **Streamlit** | Fastest path to a dense dark terminal |
+| **Charts** | **TradingView Lightweight Charts** (candles) + **ECharts** (everything else) | Best-in-class free financial charting |
+| **Map** | **Leaflet** (Phase 1) → **deck.gl/Kepler.gl** (Phase 2) | World-event visualization |
+| **Deploy** | **All self-hosted via `docker-compose`** (Postgres+pgvector, Redis, Python worker) on an **Oracle Cloud Always Free** VM (4 ARM cores / 24 GB RAM, PAYG = $0); `restart: unless-stopped`. Owned hardware or Xata free are interchangeable alternatives (see §3.1). | Truly free, always-on; identical dev/prod |
+
+**Phase-1 monthly cost: $0** (self-hosted DB + all-free data sources: yfinance, Finnhub free, FRED, GDELT, SEC EDGAR). The only optional paid line item is **Tiingo (~$30/mo)** for cleaner ML-grade history — defer it; start on yfinance and add it only if data quality bites. Real cost is electricity + your time.
+
+### Scaling stack (add only when a real bottleneck appears)
+- Database: self-hosted Postgres → add **`pg_partman` partitioning** as tables grow. Since you self-host, **TimescaleDB is now an option** (use a combined `timescaledb`+`pgvector` image) — but at this scale native partitioning + DuckDB/Parquet is simpler and sufficient (see §3.1). If you ever want a managed always-on DB instead, **Xata free** (15 GB, no pause) or a ~$5/mo VPS/managed Postgres.
+- Orchestration: APScheduler → **Prefect** (free Cloud Hobby / self-host) when jobs gain dependencies/backfills.
+- Streaming: add **NATS JetStream** or **Redpanda** *only* if you move from polling to high-rate event ingestion.
+- Analytics store: DuckDB/Parquet → **ClickHouse** (billions of rows) or **QuestDB** (tick data).
+- Search: pgvector → **Qdrant** (10M+ vectors) and/or **Meilisearch/Typesense** (keyword relevance).
+- Data sources: add **Polygon/"Massive"** ($29–$199, intraday + flat files) and **EODHD** ($100, global), **NewsData.io** ($200, commercial multilingual).
+- Models: **N-HiTS** (cheap+strong) / **TFT** (covariates + quantile forecasts) via Darts or **NeuralForecast (Nixtla)**.
+- Serving: FastAPI batch → **BentoML** for real-time inference with batching.
+- UI: Streamlit/OpenBB → **Next.js + Lightweight Charts/ECharts/deck.gl** against the same FastAPI backend.
+
+### 3.1 Database decision: self-hosted Postgres + pgvector (free), **not** Supabase, **not** TimescaleDB
+
+**Decision:** self-host **plain PostgreSQL + pgvector** in Docker on hardware you own. This is the only genuinely-free option that handles a **24/7 ingestion** workload — verified against current (June 2026) docs.
+
+**Why not Supabase / a free managed tier?** Free managed tiers are built for *idle* apps that sleep; a 24/7 poller is the opposite:
+- **Supabase Free** — 500 MB cap is the blocker (constant writes prevent the 7-day pause, but the storage fills in days). Pro is ~$25/mo. Also, Supabase dropped `timescaledb` on its PG17 default.
+- **Neon Free** — pgvector ✓, but **100 compute-hours/mo ≈ 400 h** of a ~730 h month; an always-awake poller exhausts it ~day 17, then compute suspends.
+- **Xata Free** (15 GB, no pause/cold-start) is the best *managed* free fallback if you ever stop self-hosting.
+
+**Why this is great at our scale:** one Docker container (`pgvector/pgvector:pg17`), true MVCC (poller writes while dashboard reads — no single-writer bottleneck), real HNSW/IVFFlat vector indexes, full `tsvector` FTS + JSONB, **no row/storage caps** (bounded only by disk), and complete extension freedom. Cost: $0 + electricity.
+
+**Time-series strategy (no TimescaleDB needed):**
+- **Start:** one plain table per series + **BRIN index** on the timestamp (tiny, zero maintenance).
+- **Grow:** `pg_partman` monthly range partitions + `pg_cron` for auto-create/retention.
+- **ML/aggregates + keeping the DB small:** snapshot older history to **Parquet + DuckDB** (free, on disk); keep only a hot rolling window in Postgres. DuckDB covers compression and fast time-bucketed aggregation; continuous aggregates → a `pg_cron`-refreshed materialized view.
+- Since you self-host, **TimescaleDB is available** (combined `timescaledb`+`pgvector` image) if you later want hypertables — but it's unnecessary at personal scale.
+
+**Host of record: Oracle Cloud Always Free (PAYG, $0).** Rather than depend on a home box, run the whole stack on an **Oracle Cloud Always Free** VM — **4 ARM (Ampere A1) cores / 24 GB RAM / 200 GB storage / 10 TB egress**, free indefinitely. Co-locate Postgres + Redis + the Python worker on the one VM so the DB never leaves it (the `127.0.0.1:5432` binding stays as-is); reach only the dashboard remotely over Tailscale. Provisioning checklist:
+- **Convert the account to Pay-As-You-Go (PAYG)** — disables idle-instance reclamation; you still pay **$0** within Always-Free limits. (Without PAYG, an idle VM can be reclaimed; PAYG is the reliable fix.)
+- Pick a **home region with A1 capacity** (it's fixed after signup); retry the create / use an `oci-arm-host-capacity` script if "Out of Capacity".
+- Install Docker + Tailscale; `git clone`; `docker compose up -d` — **same files, zero code change**.
+
+**Operational checklist (the honest ops burden):**
+- `restart: unless-stopped` in compose (already set); the VM is always-on.
+- **Backups (non-negotiable — no managed backups, real account-termination tail risk):** nightly `pg_dump -Fc` → **Cloudflare R2 / Backblaze B2** (free tiers); keep a rolling window. **Treat the VM as disposable** — a reclaim or ban should be a restore, not a loss.
+- **Exposure:** keep Postgres **LAN/tailnet-only**; never publish port 5432. Use a Cloudflare Tunnel only for the dashboard's web UI.
+- A **Python worker (FastAPI + APScheduler)** does heavy ingestion (GDELT, FinBERT) and ML; live updates go out over **FastAPI WebSockets/SSE** (add Redis pub/sub for fan-out later).
+
+**Alternatives:** **a machine you own** (Mac mini / old PC / Pi 5 — same stack, no capacity lottery, but you supply uptime/power), or **Xata free** managed (15 GB, no pause). The architecture is identical (it's all just Postgres), so switching is trivial. For local dev, `docker compose up` on your laptop mirrors the VM exactly.
+
+Sources: [timescaledb extension (deprecation notice)](https://supabase.com/docs/guides/database/extensions/timescaledb) · [PG17 release notes / removal](https://supabase.com/changelog/35851-forthcoming-postgres-17-release-notes) · [self-hosted PG15→17 breaking change](https://supabase.com/changelog/46080-self-hosted-supabase-upgrading-from-pg-15-to-17-breaking-change) · [pg_partman](https://supabase.com/docs/guides/database/extensions/pg_partman) · [Realtime benchmarks](https://supabase.com/docs/guides/realtime/benchmarks) · [pricing](https://supabase.com/pricing).
+
+### Notable shortcut
+**OpenBB** (open-source) solves two problems at once: its **Platform** is a free Python API over ~100 data providers (replaces ad-hoc yfinance), and **Workspace Community Edition** is a free, dense, dark, draggable terminal UI where your own FastAPI endpoints (price, news, macro, forecasts) appear as widgets via a `widgets.json` spec — **no frontend code required.**
+
+---
+
+## 4. Target architecture
+
+```
+                        ┌─────────────────── INGESTION (APScheduler jobs) ───────────────────┐
+  External sources  →   │  market_poller   macro_poller   news_poller   social_consumer      │
+  (Tiingo/Finnhub,      │       │              │              │              │                │
+   FRED/DBnomics,       │       └──────┬───────┴──────┬───────┴──────┬───────┘                │
+   GDELT/RSS,           │              ▼              ▼              ▼                         │
+   Bluesky/Reddit,      │        Pandera validation  →  quarantine bad rows                   │
+   SEC EDGAR)           └──────────────┬───────────────────────────────────────────────────┘
+                                       ▼
+                        ┌──────────────────────────────────────────────┐
+                        │  Self-hosted Postgres + pgvector (Docker)     │
+                        │   • prices (partitioned, BRIN/pg_partman)     │
+                        │   • macro_series   • sentiment  • forecasts   │
+                        │   • news_articles (JSONB + tsvector + pgvector)│
+                        │   nightly pg_dump → R2/B2 · LAN/Tailscale only │
+                        └───────────────┬──────────────────────────────┘
+                                        │
+              ┌─────────────────────────┼──────────────────────────────┐
+              ▼                         ▼                              ▼
+    ML pipeline (Darts)         FastAPI backend                 DuckDB/Parquet
+    • feature build (FinBERT    • custom endpoints + forecasts  • ATTACH Postgres +
+      sentiment + macro +       • WebSocket/SSE live updates       read Parquet history
+      technicals, lagged)       • Redis cache, ARQ workers      • feature engineering
+                                                                • archives hot DB → small
+    • walk-forward train               │
+    • MLflow tracking                  ▼
+    • batch predict → DB        ┌──────────────────────────────┐
+                                │  UI: OpenBB Workspace /        │
+                                │  Streamlit → (later) Next.js   │
+                                │  charts · news · map · macro · │
+                                │  forecasts                     │
+                                └──────────────────────────────┘
+```
+
+---
+
+## 5. Phased implementation plan
+
+Estimates assume solo, part-time effort. Each phase ends in something usable.
+
+### Phase 0 — Foundation & cleanup _(~1–2 weeks)_ — ✅ **DONE (2026-06-13)**
+**Goal: a trustworthy base.**
+- ✅ Fixed `requirements.txt` (added tensorflow, scikit-learn, matplotlib, pydantic-settings; pinned); split into `requirements.txt` + `requirements-dev.txt`; added `pyproject.toml`.
+- ✅ Added `sklearn-env/`, `.env`, model artifacts to `.gitignore`.
+- ✅ Restructured into a package: `src/market_intel/{config,data,models}/` with thin CLIs (`multi_feature_model.py`, `preprocess.py`).
+- ✅ **Fixed the LSTM leakage** (`models/windowing.py`): split first → fit feature *and* target scalers on **train only** → window strictly causally within each split; shared helper across the fixed split and walk-forward (`TimeSeriesSplit`) paths; added early stopping. Leaky baseline test RMSE 30.32 → honest 12.55 on AAPL (walk-forward mean 13.68). Verified by a 3-lens adversarial review (no leakage found).
+- ✅ Format-agnostic loader (`data/loaders.py`) handles single- *and* multi-ticker yfinance CSVs; fixed the triple-`__main__` bug in the fetcher.
+- ✅ Added `.env` + `pydantic-settings` config (`config.py`); `.env.example`.
+- ✅ `docker-compose.yml`: **`pgvector/pgvector:pg17`** + **Redis**, `restart: unless-stopped`, localhost-only, with `db/init/01_extensions.sql` enabling `vector`. Plain Postgres — **no TimescaleDB** (see §3.1). _(pg_cron deferred to Phase 1 — not in the pgvector image.)_
+- ✅ Added `pytest` (30 tests incl. strict leakage regression tests for both the fixed split and walk-forward), `ruff`/`black` config, and a real README.
+
+**Done:** the LSTM trains with honest (non-leaky) metrics; `pip install -r requirements.txt` reproduces the env; `docker compose up` provisions Postgres+pgvector+Redis. _Remaining for the user: spin up Docker on the always-on box and copy `.env.example` → `.env`._
+
+### Phase 1 — Data ingestion backbone _(~2–4 weeks)_
+**Goal: continuous, validated, multi-source ingestion into Postgres.**
+- Python worker: FastAPI app skeleton + APScheduler, connected to the local Postgres.
+- Ingestors: **market** (yfinance/Finnhub free; Tiingo optional), **macro** (FRED + DBnomics), **news/events** (GDELT DOC API + a curated FreshRSS feed set), **filings** (SEC EDGAR). All free.
+- Define normalized schema: `prices` & `macro_series` as **range-partitioned tables** (BRIN index on time to start; `pg_partman`+`pg_cron` when they grow); `news_articles` (JSONB + `tsvector` GIN + `pgvector`).
+- Pandera contracts at every ingest boundary; quarantine + log bad rows.
+- Idempotent upserts, backfill jobs, basic retry/observability.
+- Wire up the nightly `pg_dump` → R2/B2 backup job.
+
+**Done when:** scheduled jobs keep prices, macro, and global news flowing into Postgres unattended, with validation gates and off-box backups.
+
+### Phase 2 — Dashboard MVP _(~3–4 weeks)_
+**Goal: see it.**
+- Stand up the UI. **Recommended:** OpenBB Workspace + FastAPI custom backend (fastest dense terminal). Alternative: a single Streamlit app.
+- Panels: candlestick + indicators (Lightweight Charts), live news feed with ticker-level sentiment, macro dashboard, **world map of GDELT events** (Leaflet).
+- Live updates via **FastAPI WebSockets/SSE** from the worker; Redis caching for hot reads.
+
+**Done when:** one screen shows live markets + news + macro + a world event map, auto-refreshing.
+
+### Phase 3 — Clean ML forecasting layer _(~3–4 weeks)_
+**Goal: trustworthy, displayed predictions.**
+- Port the LSTM into **Darts**; enforce split-before-window, train-only scaling, walk-forward validation.
+- **FinBERT** sentiment features: score news bodies, aggregate to daily per-asset scores, **lag** them; fuse with technicals + lagged macro into one multivariate matrix.
+- **MLflow** tracking + model registry; **DVC**/Parquet snapshots for reproducible datasets.
+- Scheduled **batch prediction** → write forecasts to DB → render in the dashboard with confidence bands.
+
+**Done when:** forecasts (with honest backtests) are produced on a schedule and shown next to actuals.
+
+### Phase 4 — Intelligence & scale _(months 4–6+)_
+**Goal: from dashboard to signal engine.**
+- Semantic news search (pgvector) + entity/event extraction; LLM summaries on top-N flagged stories.
+- **Event → asset linkage**: map a remote headline to the tickers/sectors/regions it may move; volatility-regime awareness.
+- Alerting (anomaly/sentiment-spike notifications).
+- Social firehose (Bluesky Jetstream + Reddit) for early signals.
+- Model upgrades: benchmark **N-HiTS** / **TFT** (quantile forecasts, future covariates) via Darts/NeuralForecast.
+- Scale the stack as needed (Prefect, ClickHouse/QuestDB, Qdrant, BentoML, Next.js front end, Hetzner VPS).
+
+**Done when:** the system proactively surfaces "this faint event may move that asset," with model and infra that scale.
+
+---
+
+## 6. Next steps
+
+**Phase 0 is complete** (see above). Remaining setup for the user:
+1. Provision the **Oracle Cloud Always Free** VM (convert to PAYG, pick an A1-capacity region), install Docker + Tailscale, then `docker compose up -d`, `cp .env.example .env`, set `DB_PASSWORD`, and wire the nightly `pg_dump` → R2/B2 backup. _(Or run the same `docker compose up` locally to start.)_
+2. Get **free API keys** for Phase 1: FRED, Finnhub, (optional) Marketaux. Try the **GDELT DOC API** with a `curl` query — no key needed. (Tiingo is optional/paid — skip for now.)
+
+**Then Phase 1 — ingestion backbone:** uncomment the Phase-1 deps in `requirements.txt` (SQLAlchemy, psycopg, APScheduler, pandera…), define the `prices`/`macro_series`/`news_articles` schema, and stand up the first scheduled ingestors (market + FRED + GDELT) writing into Postgres with Pandera validation.
+
+## 7. Key risks & notes
+- ✅ **ML leakage** (was the #1 correctness risk) — fixed in Phase 0 and locked by `tests/test_windowing.py`.
+- **Self-hosting = you own DR & uptime** — the nightly `pg_dump` → R2/B2 is non-negotiable; keep the DB LAN-only/Tailscale (never expose port 5432); disable host sleep.
+- **No TimescaleDB** (see §3.1) — use native partitioning + `pg_partman` + DuckDB/Parquet; archive history to Parquet to keep the hot DB small. (It's *available* self-hosted but unneeded at this scale.)
+- **Vendor terms**: yfinance is unofficial/personal-use-only; GDELT explicitly allows redistribution; verify each API's storage/redistribution clause before persisting.
+- **Pricing drifts** — re-check free-tier limits (Alpha Vantage tightened to ~25/day; X API is now cost-prohibitive; IEX Cloud shut down Aug 2024; Polygon rebranded to "Massive").
+- **Scope discipline** — resist building the scaling stack early; the lean stack is deliberately small so you ship.
+```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,34 @@
+[build-system]
+requires = ["setuptools>=68"]
+build-backend = "setuptools.build_meta"
+
+[project]
+name = "market-intel"
+version = "0.1.0"
+description = "Personal global market-intelligence terminal — data ingestion + LSTM forecasting"
+requires-python = ">=3.11"
+readme = "README.md"
+dynamic = ["dependencies"]
+
+[tool.setuptools.dynamic]
+dependencies = { file = ["requirements.txt"] }
+
+[tool.setuptools.packages.find]
+where = ["src"]
+include = ["market_intel*"]
+
+[tool.pytest.ini_options]
+# Make `import market_intel` work without an editable install.
+pythonpath = ["src"]
+testpaths = ["tests"]
+addopts = "-q"
+
+[tool.ruff]
+line-length = 100
+src = ["src", "tests"]
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "UP", "B"]
+
+[tool.black]
+line-length = 100

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,6 @@
+# Development tooling. Install with:  pip install -r requirements.txt -r requirements-dev.txt
+-r requirements.txt
+
+pytest==9.0.3
+ruff==0.15.17
+black==26.5.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,21 +1,26 @@
-beautifulsoup4==4.12.3
-certifi==2024.12.14
-charset-normalizer==3.4.1
-frozendict==2.4.6
-html5lib==1.1
-idna==3.10
-lxml==5.3.0
-multitasking==0.0.11
-numpy==2.2.1
+# Runtime dependencies (Phase 0).
+# Pinned to a known-good, currently-installed set. See requirements-dev.txt for tooling.
+
+# --- ML / data ---
+numpy==2.0.2
 pandas==2.2.3
-peewee==3.17.8
-platformdirs==4.3.6
-python-dateutil==2.9.0.post0
-pytz==2024.2
-requests==2.32.3
-six==1.17.0
-soupsieve==2.6
-tzdata==2024.2
-urllib3==2.3.0
-webencodings==0.5.1
+scikit-learn==1.6.0
+tensorflow==2.18.0
+matplotlib==3.10.0
+
+# --- data sources ---
 yfinance==0.2.51
+requests==2.32.3
+
+# --- config / settings ---
+pydantic==2.13.4
+pydantic-settings==2.14.1
+
+# --- Phase 1 (uncomment as ingestion/storage lands) ---
+# SQLAlchemy>=2.0
+# psycopg[binary]>=3.2      # Postgres driver
+# redis>=5.0
+# pyarrow>=18.0             # Parquet
+# duckdb>=1.1               # analytics / ML feature layer
+# apscheduler>=3.10         # ingestion scheduling
+# pandera>=0.20             # dataframe validation

--- a/src/market_intel/__init__.py
+++ b/src/market_intel/__init__.py
@@ -1,0 +1,7 @@
+"""market_intel — personal global market-intelligence terminal.
+
+Phase 0 scope: clean, leakage-free LSTM price forecasting + a format-agnostic
+data loader + typed configuration. See docs/VISION_AND_ROADMAP.md.
+"""
+
+__version__ = "0.1.0"

--- a/src/market_intel/config.py
+++ b/src/market_intel/config.py
@@ -1,0 +1,62 @@
+"""Typed application configuration.
+
+Values come from environment variables and an optional `.env` file (see
+`.env.example`). Import the singleton `settings` or call `get_settings()`.
+"""
+
+from __future__ import annotations
+
+from functools import lru_cache
+from pathlib import Path
+from urllib.parse import quote_plus
+
+from pydantic import Field
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+
+
+class Settings(BaseSettings):
+    model_config = SettingsConfigDict(
+        env_file=".env",
+        env_file_encoding="utf-8",
+        extra="ignore",
+    )
+
+    # --- Database (self-hosted Postgres + pgvector) ---
+    db_host: str = "localhost"
+    db_port: int = 5432
+    db_name: str = "market_intel"
+    db_user: str = "market_intel"
+    db_password: str = "change_me"
+
+    # --- Redis ---
+    redis_url: str = "redis://localhost:6379/0"
+
+    # --- Data source API keys (optional in Phase 0) ---
+    fred_api_key: str | None = None
+    finnhub_api_key: str | None = None
+    tiingo_api_key: str | None = None
+    marketaux_api_key: str | None = None
+
+    # --- Paths ---
+    data_dir: Path = Field(default=REPO_ROOT / "data")
+    models_dir: Path = Field(default=REPO_ROOT / "models")
+
+    @property
+    def database_url(self) -> str:
+        """SQLAlchemy/psycopg connection URL (credentials percent-encoded)."""
+        user = quote_plus(self.db_user)
+        password = quote_plus(self.db_password)
+        return (
+            f"postgresql+psycopg://{user}:{password}"
+            f"@{self.db_host}:{self.db_port}/{self.db_name}"
+        )
+
+
+@lru_cache
+def get_settings() -> Settings:
+    return Settings()
+
+
+settings = get_settings()

--- a/src/market_intel/data/__init__.py
+++ b/src/market_intel/data/__init__.py
@@ -1,0 +1,5 @@
+"""Data loading and fetching."""
+
+from market_intel.data.loaders import load_price_frame, load_prices
+
+__all__ = ["load_price_frame", "load_prices"]

--- a/src/market_intel/data/fetch.py
+++ b/src/market_intel/data/fetch.py
@@ -1,0 +1,64 @@
+"""Fetch historical price CSVs from yfinance.
+
+Replaces the original ``preprocess.py``, which had three ``__main__`` blocks
+(all executed in sequence, and the third raised ``TypeError`` from a wrong-arity
+call). Here each dataset is a declarative entry and ``main()`` fetches them all.
+
+yfinance is unofficial / personal-use only and has no SLA — fine for prototyping;
+Phase 1 adds a vetted source (Tiingo/Finnhub). See docs/VISION_AND_ROADMAP.md.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+import yfinance as yf
+
+DEFAULT_START = "2015-01-01"
+DEFAULT_END = "2023-12-31"
+
+
+@dataclass(frozen=True)
+class Dataset:
+    tickers: str  # space-separated, e.g. "AAPL MSFT"
+    save_path: str
+    start: str = DEFAULT_START
+    end: str = DEFAULT_END
+
+
+DATASETS: tuple[Dataset, ...] = (
+    Dataset("AAPL", "data/aapl_stock_data.csv"),
+    Dataset("AAPL MSFT GOOGL AMZN META NVDA", "data/tech_stock_data.csv"),
+    Dataset("VOO VTI VUG VTV VYM", "data/index_fund_stock_data.csv"),
+)
+
+
+def fetch_stock_data(tickers: str, start: str, end: str, save_path: str) -> bool:
+    """Download ``tickers`` between ``start`` and ``end`` and save to ``save_path``.
+
+    Returns True if data was written, False on no/all-NaN data or any error.
+    yfinance is unofficial and flaky, so failures are caught and reported rather
+    than raised — one bad dataset shouldn't abort the rest.
+    """
+    try:
+        data = yf.download(tickers, start=start, end=end)
+    except Exception as exc:  # noqa: BLE001 — yfinance raises a variety of errors
+        print(f"Failed to download {tickers!r}: {exc}")
+        return False
+    if data.empty or data.dropna(how="all").empty:
+        print(f"No usable data for tickers {tickers!r}.")
+        return False
+    os.makedirs(os.path.dirname(save_path) or ".", exist_ok=True)
+    data.to_csv(save_path)
+    print(f"Data saved to {save_path}")
+    return True
+
+
+def main(datasets: tuple[Dataset, ...] = DATASETS) -> None:
+    for ds in datasets:
+        fetch_stock_data(ds.tickers, ds.start, ds.end, ds.save_path)
+
+
+if __name__ == "__main__":
+    main()

--- a/src/market_intel/data/loaders.py
+++ b/src/market_intel/data/loaders.py
@@ -1,0 +1,101 @@
+"""Format-agnostic loaders for yfinance price CSVs.
+
+yfinance writes two shapes that the original single-format loader could not both
+handle:
+
+* single-ticker (``aapl_stock_data.csv``) — one ticker, 5 fields;
+* multi-ticker (``tech_stock_data.csv``) — N tickers wide, 5 fields each.
+
+Both share a 2-row column header ``(field, ticker)``. yfinance usually also
+writes an index-name row (``Date,,,``) as the third line; we drop it *by
+detecting non-parseable dates* rather than blindly skipping a fixed row, so a
+file written without that row keeps all its real data.
+"""
+
+from __future__ import annotations
+
+import warnings
+from pathlib import Path
+
+import pandas as pd
+
+DEFAULT_FIELDS = ("Close", "High", "Low", "Open", "Volume")
+
+
+def load_price_frame(path: str | Path) -> pd.DataFrame:
+    """Parse a yfinance CSV into a DataFrame with a ``(field, ticker)`` column
+    MultiIndex and a sorted ``DatetimeIndex``.
+
+    Handles both single- and multi-ticker exports, strips header/value
+    whitespace, drops any non-date index rows (incl. the spurious ``Date``
+    index-name row *if present*), and coerces values to numeric.
+
+    Raises ``FileNotFoundError`` if missing and ``ValueError`` if no rows parse.
+    """
+    path = Path(path)
+    if not path.exists():
+        raise FileNotFoundError(f"Price file not found: {path}")
+
+    df = pd.read_csv(path, header=[0, 1], index_col=0)
+    df.columns = pd.MultiIndex.from_tuples(
+        [(str(field).strip(), str(ticker).strip()) for field, ticker in df.columns]
+    )
+    # Drop rows whose index isn't a real date — this removes the "Date,,," row
+    # only when it exists, never a genuine first data row. We intentionally
+    # coerce non-dates to NaT, so silence the mixed-format inference warning.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", category=UserWarning)
+        df.index = pd.to_datetime(df.index, errors="coerce")
+    df = df[df.index.notna()]
+    df.index.name = "Date"
+    df = df.apply(pd.to_numeric, errors="coerce").sort_index()
+
+    if df.empty:
+        raise ValueError(f"No parseable date rows in {path} — unexpected file format")
+    return df
+
+
+def load_prices(
+    ticker: str,
+    data_dir: str | Path = "data",
+    dataset: str | None = None,
+    fields: tuple[str, ...] = DEFAULT_FIELDS,
+) -> pd.DataFrame:
+    """Load a single ticker's OHLCV history as a tidy DataFrame.
+
+    Parameters
+    ----------
+    ticker:
+        e.g. ``"AAPL"``. Case-insensitive (both the filename and the in-file
+        column match).
+    data_dir:
+        Directory containing the CSV files.
+    dataset:
+        Optional dataset name (e.g. ``"tech"`` -> ``tech_stock_data.csv``).
+        Defaults to the per-ticker file ``<ticker>_stock_data.csv``.
+    fields:
+        Columns to return, in order. Defaults to Close/High/Low/Open/Volume.
+
+    Returns
+    -------
+    DataFrame indexed by date with one column per field, rows with a missing
+    value in any requested field dropped.
+    """
+    data_dir = Path(data_dir)
+    stem = dataset if dataset is not None else ticker.lower()
+    path = data_dir / f"{stem}_stock_data.csv"
+
+    frame = load_price_frame(path)
+    available = list(frame.columns.get_level_values(1).unique())
+    canonical = {t.upper(): t for t in available}
+    if ticker.upper() not in canonical:
+        raise KeyError(f"Ticker {ticker!r} not in {path.name} (has: {available})")
+    resolved = canonical[ticker.upper()]
+
+    sub = frame.xs(resolved, axis=1, level=1)
+    missing = [f for f in fields if f not in sub.columns]
+    if missing:
+        raise KeyError(f"Fields {missing} not in {path.name} for {resolved}")
+
+    sub = sub[list(fields)]
+    return sub.dropna(subset=list(fields))

--- a/src/market_intel/models/__init__.py
+++ b/src/market_intel/models/__init__.py
@@ -1,0 +1,15 @@
+"""Modeling layer.
+
+``windowing`` is TensorFlow-free and safe to import anywhere. Import the LSTM
+explicitly (``from market_intel.models.lstm import run``) so TensorFlow only
+loads when you actually train.
+"""
+
+from market_intel.models.windowing import (
+    SplitData,
+    WalkForwardFold,
+    prepare_splits,
+    walk_forward_splits,
+)
+
+__all__ = ["SplitData", "WalkForwardFold", "prepare_splits", "walk_forward_splits"]

--- a/src/market_intel/models/lstm.py
+++ b/src/market_intel/models/lstm.py
@@ -1,0 +1,241 @@
+"""LSTM price forecasting — leakage-free training, evaluation, and walk-forward CV.
+
+Same model architecture as the original ``multi_feature_model.py`` (2x LSTM(50)
++ Dropout + Dense), but fed by ``windowing.prepare_splits`` so the scaler is fit
+on train only and windows never cross split boundaries. Adds a walk-forward
+(expanding-window) evaluator, the realistic way to score a time-series model.
+"""
+
+from __future__ import annotations
+
+import os
+import random
+from dataclasses import dataclass, field
+
+import numpy as np
+import pandas as pd
+from sklearn.metrics import mean_absolute_error, mean_squared_error
+
+from market_intel.data.loaders import load_prices
+from market_intel.models.windowing import (
+    DEFAULT_FIELDS,
+    SplitData,
+    prepare_splits,
+    walk_forward_splits,
+)
+
+
+def set_seeds(seed: int = 42) -> None:
+    """Best-effort reproducibility (CPU)."""
+    os.environ["PYTHONHASHSEED"] = str(seed)
+    random.seed(seed)
+    np.random.seed(seed)
+    import tensorflow as tf
+
+    tf.random.set_seed(seed)
+
+
+def build_model(time_step: int, n_features: int, units: int = 50, dropout: float = 0.2):
+    """Build and compile the LSTM. Imports TensorFlow lazily."""
+    from tensorflow.keras import Input, Sequential
+    from tensorflow.keras.layers import LSTM, Dense, Dropout
+
+    model = Sequential(
+        [
+            Input(shape=(time_step, n_features)),
+            LSTM(units, return_sequences=True),
+            Dropout(dropout),
+            LSTM(units, return_sequences=False),
+            Dropout(dropout),
+            Dense(25, activation="relu"),
+            Dense(1),
+        ]
+    )
+    model.compile(optimizer="adam", loss="mean_squared_error")
+    return model
+
+
+def _rmse(y_true: np.ndarray, y_pred: np.ndarray) -> float:
+    return float(np.sqrt(mean_squared_error(y_true, y_pred)))
+
+
+@dataclass
+class TrainResult:
+    metrics: dict[str, float]
+    test_index: pd.Index
+    y_test_actual: np.ndarray
+    y_test_pred: np.ndarray
+    model: object = field(repr=False, default=None)
+
+
+def train_evaluate(
+    split: SplitData,
+    epochs: int = 20,
+    batch_size: int = 32,
+    verbose: int = 0,
+    seed: int = 42,
+    early_stopping_patience: int = 5,
+) -> TrainResult:
+    """Train on the prepared split and return price-unit RMSE/MAE per partition.
+
+    When a validation split exists, EarlyStopping(restore_best_weights=True)
+    uses it for model selection. This is leakage-free: EarlyStopping only reads
+    ``val_loss`` and never folds val data into weights or scaling.
+    """
+    set_seeds(seed)
+    model = build_model(split.time_step, split.X_train.shape[2])
+
+    validation_data = (split.X_val, split.y_val) if len(split.X_val) else None
+    callbacks = []
+    if validation_data is not None and early_stopping_patience:
+        from tensorflow.keras.callbacks import EarlyStopping
+
+        callbacks.append(
+            EarlyStopping(
+                monitor="val_loss",
+                patience=early_stopping_patience,
+                restore_best_weights=True,
+            )
+        )
+    model.fit(
+        split.X_train,
+        split.y_train,
+        validation_data=validation_data,
+        epochs=epochs,
+        batch_size=batch_size,
+        verbose=verbose,
+        callbacks=callbacks,
+    )
+
+    metrics: dict[str, float] = {}
+    partitions = {"train": (split.X_train, split.y_train), "test": (split.X_test, split.y_test)}
+    if validation_data is not None:
+        partitions["val"] = (split.X_val, split.y_val)
+
+    test_actual = test_pred = None
+    for name, (X, y) in partitions.items():
+        if not len(X):
+            continue
+        pred = split.inverse_target(model.predict(X, verbose=0))
+        actual = split.inverse_target(y)
+        metrics[f"{name}_rmse"] = _rmse(actual, pred)
+        metrics[f"{name}_mae"] = float(mean_absolute_error(actual, pred))
+        if name == "test":
+            test_actual, test_pred = actual, pred
+
+    return TrainResult(
+        metrics=metrics,
+        test_index=split.test_index,
+        y_test_actual=test_actual if test_actual is not None else np.empty((0,)),
+        y_test_pred=test_pred if test_pred is not None else np.empty((0,)),
+        model=model,
+    )
+
+
+def walk_forward_eval(
+    df: pd.DataFrame,
+    feature_cols: tuple[str, ...] = DEFAULT_FIELDS,
+    target_col: str = "Close",
+    time_step: int = 60,
+    n_splits: int = 5,
+    epochs: int = 10,
+    batch_size: int = 32,
+    verbose: int = 0,
+    seed: int = 42,
+) -> dict:
+    """Expanding-window walk-forward CV (sklearn ``TimeSeriesSplit``).
+
+    Each fold trains only on its past and tests on the immediately following
+    rows; scalers are re-fit on each fold's train slice (no leakage across folds).
+    Fold construction lives in the TF-free ``windowing.walk_forward_splits`` so
+    the leakage discipline is shared with ``prepare_splits`` and unit-testable.
+    Returns per-fold test RMSE/MAE and their means.
+    """
+    wf_folds = walk_forward_splits(
+        df, feature_cols=feature_cols, target_col=target_col, time_step=time_step, n_splits=n_splits
+    )
+    if not wf_folds:
+        raise RuntimeError("no usable folds — reduce time_step or n_splits")
+
+    folds: list[dict] = []
+    for f in wf_folds:
+        set_seeds(seed + f.fold)  # per-fold diversity
+        model = build_model(time_step, f.X_train.shape[2])
+        model.fit(f.X_train, f.y_train, epochs=epochs, batch_size=batch_size, verbose=verbose)
+
+        pred = f.inverse_target(model.predict(f.X_test, verbose=0))
+        actual = f.inverse_target(f.y_test)
+        folds.append(
+            {
+                "fold": f.fold,
+                "train_end": f.train_end,
+                "n_test": int(len(f.y_test)),
+                "rmse": _rmse(actual, pred),
+                "mae": float(mean_absolute_error(actual, pred)),
+            }
+        )
+
+    return {
+        "folds": folds,
+        "mean_rmse": float(np.mean([f["rmse"] for f in folds])),
+        "mean_mae": float(np.mean([f["mae"] for f in folds])),
+    }
+
+
+def run(
+    ticker: str,
+    dataset: str | None = None,
+    data_dir: str = "data",
+    time_step: int = 60,
+    epochs: int = 20,
+    batch_size: int = 32,
+    plot: bool = False,
+    plot_path: str | None = None,
+    walk_forward: int = 0,
+    verbose: int = 0,
+) -> dict:
+    """Load a ticker, train a leakage-free LSTM, print and return metrics."""
+    df = load_prices(ticker, data_dir=data_dir, dataset=dataset)
+    split = prepare_splits(df, time_step=time_step)
+    result = train_evaluate(split, epochs=epochs, batch_size=batch_size, verbose=verbose)
+
+    print(f"\n=== {ticker} — single chronological split (leakage-free) ===")
+    for k in ("train_rmse", "val_rmse", "test_rmse", "test_mae"):
+        if k in result.metrics:
+            print(f"  {k:>10}: {result.metrics[k]:.4f}")
+
+    out: dict = {"ticker": ticker, "metrics": result.metrics}
+
+    if walk_forward:
+        wf = walk_forward_eval(df, time_step=time_step, n_splits=walk_forward, epochs=epochs)
+        print(f"\n=== {ticker} — walk-forward ({len(wf['folds'])} folds) ===")
+        for f in wf["folds"]:
+            print(f"  fold {f['fold']}: test RMSE {f['rmse']:.4f}  (n_test={f['n_test']})")
+        print(f"  mean test RMSE: {wf['mean_rmse']:.4f}")
+        out["walk_forward"] = wf
+
+    if plot:
+        _plot(ticker, result, plot_path)
+
+    return out
+
+
+def _plot(ticker: str, result: TrainResult, plot_path: str | None) -> None:
+    import matplotlib
+
+    if plot_path:
+        matplotlib.use("Agg")
+    import matplotlib.pyplot as plt
+
+    plt.figure(figsize=(12, 6))
+    plt.plot(result.test_index, result.y_test_actual, label="Actual")
+    plt.plot(result.test_index, result.y_test_pred, label="Predicted")
+    plt.legend()
+    plt.title(f"Stock Price Prediction for {ticker}")
+    plt.xlabel("Date")
+    plt.ylabel("Price")
+    if plot_path:
+        plt.savefig(plot_path, bbox_inches="tight")
+        print(f"\nSaved plot to {plot_path}")
+    else:
+        plt.show()

--- a/src/market_intel/models/windowing.py
+++ b/src/market_intel/models/windowing.py
@@ -1,0 +1,235 @@
+"""Leakage-free sequence construction for time-series models.
+
+The original pipeline fit the scaler on the *entire* dataset and built sliding
+windows *before* splitting — both leak future information into training and
+inflate reported accuracy. This module enforces the correct discipline:
+
+1. Split chronologically *first* (by row position).
+2. Fit scalers on the **train slice only**, then transform val/test with them.
+3. Build windows per split so a window's target never crosses into a future
+   split. Earlier rows are allowed only as *past* look-back context, which is
+   information genuinely available at prediction time.
+
+Both ``prepare_splits`` (fixed 3-way split) and ``walk_forward_splits``
+(expanding-window CV) share ``_fit_train_scalers`` and ``_windows`` so the
+leakage-free discipline cannot drift between the two code paths. See the tests
+in tests/test_windowing.py.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+import numpy as np
+import pandas as pd
+from sklearn.model_selection import TimeSeriesSplit
+from sklearn.preprocessing import MinMaxScaler
+
+DEFAULT_FIELDS = ("Close", "High", "Low", "Open", "Volume")
+
+
+@dataclass
+class SplitData:
+    X_train: np.ndarray
+    y_train: np.ndarray
+    X_val: np.ndarray
+    y_val: np.ndarray
+    X_test: np.ndarray
+    y_test: np.ndarray
+    feature_scaler: MinMaxScaler
+    target_scaler: MinMaxScaler
+    target_col: str
+    time_step: int
+    train_end: int
+    val_end: int
+    # target row positions for each split (for index alignment / leakage checks)
+    train_pos: np.ndarray
+    val_pos: np.ndarray
+    test_pos: np.ndarray
+    index: pd.Index
+
+    @property
+    def test_index(self) -> pd.Index:
+        return self.index[self.test_pos]
+
+    def inverse_target(self, scaled: np.ndarray) -> np.ndarray:
+        """Map model output (target-scaler space) back to price units."""
+        scaled = np.asarray(scaled).reshape(-1, 1)
+        return self.target_scaler.inverse_transform(scaled).ravel()
+
+
+@dataclass
+class WalkForwardFold:
+    fold: int
+    train_end: int
+    stop: int
+    X_train: np.ndarray
+    y_train: np.ndarray
+    X_test: np.ndarray
+    y_test: np.ndarray
+    feature_scaler: MinMaxScaler
+    target_scaler: MinMaxScaler
+
+    def inverse_target(self, scaled: np.ndarray) -> np.ndarray:
+        scaled = np.asarray(scaled).reshape(-1, 1)
+        return self.target_scaler.inverse_transform(scaled).ravel()
+
+
+def chronological_split_indices(
+    n: int, train_frac: float = 0.70, val_frac: float = 0.15
+) -> tuple[int, int]:
+    """Return ``(train_end, val_end)`` row positions for a chronological split."""
+    if not 0 < train_frac < 1 or not 0 <= val_frac < 1 or train_frac + val_frac >= 1:
+        raise ValueError("require 0<train_frac<1, 0<=val_frac, train_frac+val_frac<1")
+    train_end = int(n * train_frac)
+    val_end = int(n * (train_frac + val_frac))
+    return train_end, val_end
+
+
+def _fit_train_scalers(
+    values: np.ndarray, train_end: int, target_col_idx: int
+) -> tuple[MinMaxScaler, MinMaxScaler, np.ndarray, np.ndarray]:
+    """Fit feature + target scalers on the TRAIN slice only, then transform all.
+
+    The single place scalers are fit. ``fit`` sees only ``values[:train_end]``;
+    transforming later rows with those train-derived min/max is legitimate
+    inference behavior, not leakage.
+    """
+    target = values[:, target_col_idx : target_col_idx + 1]
+    feature_scaler = MinMaxScaler((0, 1)).fit(values[:train_end])
+    target_scaler = MinMaxScaler((0, 1)).fit(target[:train_end])
+    return (
+        feature_scaler,
+        target_scaler,
+        feature_scaler.transform(values),
+        target_scaler.transform(target),
+    )
+
+
+def _windows(
+    feat_scaled: np.ndarray,
+    target_scaled: np.ndarray,
+    lo: int,
+    hi: int,
+    time_step: int,
+) -> tuple[np.ndarray, np.ndarray, np.ndarray]:
+    """Windows whose *target* row ``i`` lies in ``[max(lo, time_step), hi)``.
+
+    The input window is ``feat_scaled[i-time_step:i]`` (strictly past rows, the
+    half-open slice excludes ``i``), so no window ever peeks at or beyond its own
+    target.
+    """
+    start = max(lo, time_step)
+    xs, ys, pos = [], [], []
+    for i in range(start, hi):
+        xs.append(feat_scaled[i - time_step : i, :])
+        ys.append(target_scaled[i, 0])
+        pos.append(i)
+    if not xs:
+        n_features = feat_scaled.shape[1]
+        empty_x = np.empty((0, time_step, n_features))
+        return empty_x, np.empty((0,)), np.empty((0,), dtype=int)
+    return np.asarray(xs), np.asarray(ys), np.asarray(pos, dtype=int)
+
+
+def prepare_splits(
+    df: pd.DataFrame,
+    feature_cols: tuple[str, ...] = DEFAULT_FIELDS,
+    target_col: str = "Close",
+    time_step: int = 60,
+    train_frac: float = 0.70,
+    val_frac: float = 0.15,
+) -> SplitData:
+    """Build leakage-free train/val/test sequences from a price frame."""
+    if target_col not in feature_cols:
+        raise ValueError(f"target_col {target_col!r} must be in feature_cols")
+
+    values = df[list(feature_cols)].to_numpy(dtype="float64")
+    n = len(values)
+    if n <= time_step + 2:
+        raise ValueError(f"need more than time_step+2={time_step + 2} rows, got {n}")
+
+    train_end, val_end = chronological_split_indices(n, train_frac, val_frac)
+    if train_end <= time_step:
+        raise ValueError(
+            f"train slice ({train_end}) must exceed time_step ({time_step}); "
+            "use a smaller time_step or more data"
+        )
+
+    tcol = feature_cols.index(target_col)
+    feature_scaler, target_scaler, feat_scaled, target_scaled = _fit_train_scalers(
+        values, train_end, tcol
+    )
+
+    X_train, y_train, train_pos = _windows(feat_scaled, target_scaled, 0, train_end, time_step)
+    X_val, y_val, val_pos = _windows(feat_scaled, target_scaled, train_end, val_end, time_step)
+    X_test, y_test, test_pos = _windows(feat_scaled, target_scaled, val_end, n, time_step)
+
+    return SplitData(
+        X_train=X_train,
+        y_train=y_train,
+        X_val=X_val,
+        y_val=y_val,
+        X_test=X_test,
+        y_test=y_test,
+        feature_scaler=feature_scaler,
+        target_scaler=target_scaler,
+        target_col=target_col,
+        time_step=time_step,
+        train_end=train_end,
+        val_end=val_end,
+        train_pos=train_pos,
+        val_pos=val_pos,
+        test_pos=test_pos,
+        index=df.index,
+    )
+
+
+def walk_forward_splits(
+    df: pd.DataFrame,
+    feature_cols: tuple[str, ...] = DEFAULT_FIELDS,
+    target_col: str = "Close",
+    time_step: int = 60,
+    n_splits: int = 5,
+) -> list[WalkForwardFold]:
+    """Build leakage-free expanding-window folds (sklearn ``TimeSeriesSplit``).
+
+    TensorFlow-free so the leakage discipline can be unit-tested without training.
+    Each fold fits scalers on its own train slice (past only) and windows the
+    immediately-following test rows. Folds whose train slice is shorter than
+    ``time_step`` are skipped.
+    """
+    if target_col not in feature_cols:
+        raise ValueError(f"target_col {target_col!r} must be in feature_cols")
+
+    values = df[list(feature_cols)].to_numpy(dtype="float64")
+    tcol = feature_cols.index(target_col)
+    n = len(values)
+
+    folds: list[WalkForwardFold] = []
+    for fold, (train_idx, test_idx) in enumerate(TimeSeriesSplit(n_splits=n_splits).split(np.arange(n))):
+        train_end = int(train_idx[-1]) + 1
+        stop = int(test_idx[-1]) + 1
+        if train_end <= time_step:
+            continue
+
+        feat_scaler, tgt_scaler, feat_s, tgt_s = _fit_train_scalers(values, train_end, tcol)
+        X_tr, y_tr, _ = _windows(feat_s, tgt_s, 0, train_end, time_step)
+        X_te, y_te, _ = _windows(feat_s, tgt_s, train_end, stop, time_step)
+        if not len(X_tr) or not len(X_te):
+            continue
+
+        folds.append(
+            WalkForwardFold(
+                fold=fold,
+                train_end=train_end,
+                stop=stop,
+                X_train=X_tr,
+                y_train=y_tr,
+                X_test=X_te,
+                y_test=y_te,
+                feature_scaler=feat_scaler,
+                target_scaler=tgt_scaler,
+            )
+        )
+    return folds

--- a/src/multi_feature_model.py
+++ b/src/multi_feature_model.py
@@ -1,101 +1,50 @@
-import pandas as pd
-import numpy as np
-from sklearn.preprocessing import MinMaxScaler
-from sklearn.metrics import mean_squared_error, mean_absolute_error
-from tensorflow.keras.models import Sequential
-from tensorflow.keras.layers import LSTM, Dense, Dropout
-import matplotlib.pyplot as plt
+"""Thin CLI for the leakage-free LSTM. Real logic lives in market_intel.models.lstm.
+
+Usage:
+    python src/multi_feature_model.py AAPL
+    python src/multi_feature_model.py MSFT --dataset tech --plot
+    python src/multi_feature_model.py AAPL --walk-forward 5 --epochs 20
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
 import sys
 
-# Parse the stock ticker from command line arguments
-if len(sys.argv) != 2:
-    print("Usage: python multi_feature_model.py <STOCK_TICKER>")
-    sys.exit(1)
+# Allow running as a loose script (`python src/multi_feature_model.py`) without install.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
 
-ticker = sys.argv[1]
+from market_intel.models.lstm import run  # noqa: E402
 
-# Load data
-data = pd.read_csv(f'data/{ticker.lower()}_stock_data.csv', skiprows=2)
-data.columns = ['Date', 'Close', 'High', 'Low', 'Open', 'Volume']
-data['Date'] = pd.to_datetime(data['Date'])
-data.set_index('Date', inplace=True)
 
-# Normalize features
-scaler = MinMaxScaler(feature_range=(0, 1))
-scaled_data = scaler.fit_transform(data[['Close', 'High', 'Low', 'Open', 'Volume']])
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(description="Leakage-free LSTM stock-price forecasting")
+    p.add_argument("ticker", help="e.g. AAPL")
+    p.add_argument("--dataset", default=None, help="file stem, e.g. 'tech' (default: <ticker>)")
+    p.add_argument("--data-dir", default="data")
+    p.add_argument("--time-step", type=int, default=60)
+    p.add_argument("--epochs", type=int, default=20)
+    p.add_argument("--batch-size", type=int, default=32)
+    p.add_argument("--walk-forward", type=int, default=0, metavar="N", help="N walk-forward folds")
+    p.add_argument("--plot", action="store_true")
+    p.add_argument("--plot-path", default=None, help="save plot to file instead of showing")
+    p.add_argument("--verbose", type=int, default=1)
+    args = p.parse_args(argv)
 
-# Prepare features and targets
-def create_dataset(dataset, time_step=60):
-    X, Y = [], []
-    for i in range(time_step, len(dataset)):
-        X.append(dataset[i-time_step:i, :])  # Input features
-        Y.append(dataset[i, 0])  # 'Close' price as target
-    return np.array(X), np.array(Y)
+    run(
+        ticker=args.ticker,
+        dataset=args.dataset,
+        data_dir=args.data_dir,
+        time_step=args.time_step,
+        epochs=args.epochs,
+        batch_size=args.batch_size,
+        plot=args.plot,
+        plot_path=args.plot_path,
+        walk_forward=args.walk_forward,
+        verbose=args.verbose,
+    )
 
-time_step = 60
-X, Y = create_dataset(scaled_data, time_step)
 
-# Split into training, validation, and testing sets
-train_size = int(len(X) * 0.7)
-val_size = int(len(X) * 0.2)
-
-X_train, Y_train = X[:train_size], Y[:train_size]
-X_val, Y_val = X[train_size:train_size + val_size], Y[train_size:train_size + val_size]
-X_test, Y_test = X[train_size + val_size:], Y[train_size + val_size:]
-
-# Build the LSTM model
-model = Sequential([
-    LSTM(50, return_sequences=True, input_shape=(X_train.shape[1], X_train.shape[2])),
-    Dropout(0.2),
-    LSTM(50, return_sequences=False),
-    Dropout(0.2),
-    Dense(25, activation='relu'),
-    Dense(1)
-])
-
-# Compile the model
-model.compile(optimizer='adam', loss='mean_squared_error')
-
-# Train the model
-history = model.fit(X_train, Y_train, validation_data=(X_val, Y_val), epochs=20, batch_size=32, verbose=1)
-
-# Make predictions
-train_predictions = model.predict(X_train)
-val_predictions = model.predict(X_val)
-test_predictions = model.predict(X_test)
-
-# Create a new scaler specifically for 'Close' column
-scaler_close = MinMaxScaler(feature_range=(0, 1))
-scaled_close = scaler_close.fit_transform(data[['Close']])
-
-# Inverse transform predictions and actual values using the new scaler
-train_predictions = scaler_close.inverse_transform(train_predictions)
-val_predictions = scaler_close.inverse_transform(val_predictions)
-test_predictions = scaler_close.inverse_transform(test_predictions)
-
-Y_train_actual = scaler_close.inverse_transform(Y_train.reshape(-1, 1))
-Y_val_actual = scaler_close.inverse_transform(Y_val.reshape(-1, 1))
-Y_test_actual = scaler_close.inverse_transform(Y_test.reshape(-1, 1))
-
-# Evaluate the model
-train_rmse = np.sqrt(mean_squared_error(Y_train_actual, train_predictions))
-val_rmse = np.sqrt(mean_squared_error(Y_val_actual, val_predictions))
-test_rmse = np.sqrt(mean_squared_error(Y_test_actual, test_predictions))
-print(f"Train RMSE: {train_rmse}")
-print(f"Validation RMSE: {val_rmse}")
-print(f"Test RMSE: {test_rmse}")
-
-# Visualize 
-test_index = data.index[train_size + val_size:train_size + val_size + len(Y_test_actual)]
-
-Y_test_actual = Y_test_actual.flatten()
-test_predictions = test_predictions.flatten()
-
-plt.figure(figsize=(12, 6))
-plt.plot(test_index, Y_test_actual, label="Testing Data Actual")
-plt.plot(test_index, test_predictions, label="Testing Data Predictions")
-plt.legend()
-plt.title(f'Stock Price Prediction for {ticker}')  # Dynamic title
-plt.xlabel("Date")
-plt.ylabel("Price")
-plt.show()
+if __name__ == "__main__":
+    main()

--- a/src/preprocess.py
+++ b/src/preprocess.py
@@ -1,34 +1,17 @@
-import yfinance as yf
+"""Thin entrypoint for fetching price CSVs. Logic lives in market_intel.data.fetch.
+
+Usage:
+    python src/preprocess.py
+"""
+
+from __future__ import annotations
+
 import os
+import sys
 
-def fetch_stock_data(ticker, start_date, end_date, save_path):
-    # Fetch stock data
-    data = yf.download(ticker, start=start_date, end=end_date)
-    if not data.empty:
-        # Save to CSV
-        os.makedirs(os.path.dirname(save_path), exist_ok=True)
-        data.to_csv(save_path)
-        print(f"Data saved to {save_path}")
-    else:
-        print(f"No data found for ticker {ticker}.")
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+from market_intel.data.fetch import main  # noqa: E402
 
 if __name__ == "__main__":
-    ticker = "AAPL"
-    start_date = "2015-01-01"
-    end_date = "2023-12-31"
-    save_path = "data/apple_stock_data.csv"
-    fetch_stock_data(ticker, start_date, end_date, save_path)
-
-
-if __name__ == "__main__":
-    tickers = 'AAPL MSFT GOOGL AMZN META NVDA' # Get multiple tech tickers
-    start_date = "2015-01-01"
-    end_date = "2023-12-31"
-    save_path = "data/tech_stock_data.csv"
-    fetch_stock_data(tickers, start_date, end_date, save_path)
-    
-if __name__ == "__main__":
-    tickers = 'VOO VTI VUG VTV VYM' # Get multiple index funds tickers #test
-    end_date = "2023-12-31"
-    save_path = "data/index_fund_stock_data.csv"
-    fetch_stock_data(tickers, start_date, end_date, save_path)
+    main()

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,20 @@
+"""Configuration loads with sane defaults and builds a DB URL."""
+
+from market_intel.config import Settings
+
+
+def test_defaults_and_database_url():
+    s = Settings(_env_file=None)
+    assert s.db_port == 5432
+    assert s.db_name == "market_intel"
+    url = s.database_url
+    assert url.startswith("postgresql+psycopg://")
+    assert "@localhost:5432/market_intel" in url
+
+
+def test_env_override(monkeypatch):
+    monkeypatch.setenv("DB_HOST", "db.internal")
+    monkeypatch.setenv("DB_PASSWORD", "secret")
+    s = Settings(_env_file=None)
+    assert s.db_host == "db.internal"
+    assert "secret@db.internal" in s.database_url

--- a/tests/test_loaders.py
+++ b/tests/test_loaders.py
@@ -1,0 +1,85 @@
+"""Loader handles both single- and multi-ticker yfinance CSV shapes."""
+
+import pandas as pd
+import pytest
+
+from market_intel.data.loaders import load_price_frame, load_prices
+
+DATA_DIR = "data"
+FIELDS = ["Close", "High", "Low", "Open", "Volume"]
+
+
+def test_load_single_ticker():
+    df = load_prices("AAPL", data_dir=DATA_DIR)
+    assert list(df.columns) == FIELDS
+    assert isinstance(df.index, pd.DatetimeIndex)
+    assert df.index.is_monotonic_increasing
+    assert df["Close"].isna().sum() == 0
+    assert len(df) > 2000
+
+
+def test_load_ticker_from_multi_ticker_file():
+    msft = load_prices("MSFT", data_dir=DATA_DIR, dataset="tech")
+    aapl = load_prices("AAPL", data_dir=DATA_DIR, dataset="tech")
+    assert list(msft.columns) == FIELDS
+    assert msft["Close"].isna().sum() == 0
+    # different tickers -> different series
+    assert not msft["Close"].equals(aapl["Close"])
+
+
+def test_multi_ticker_frame_exposes_all_tickers():
+    frame = load_price_frame(f"{DATA_DIR}/tech_stock_data.csv")
+    tickers = set(frame.columns.get_level_values(1))
+    assert {"AAPL", "AMZN", "GOOGL", "META", "MSFT", "NVDA"} <= tickers
+
+
+def test_unknown_ticker_raises():
+    with pytest.raises(KeyError):
+        load_prices("NOPE", data_dir=DATA_DIR, dataset="tech")
+
+
+def test_missing_file_raises():
+    with pytest.raises(FileNotFoundError):
+        load_prices("AAPL", data_dir="data", dataset="does_not_exist")
+
+
+# --- synthetic CSVs (no dependency on committed data) ---
+
+
+def test_csv_without_index_name_row_keeps_all_rows(tmp_path):
+    """The old hardcoded skiprows=[2] would silently drop the first data row."""
+    (tmp_path / "xyz_stock_data.csv").write_text(
+        "Price,Close,High,Low,Open,Volume\n"
+        "Ticker,XYZ,XYZ,XYZ,XYZ,XYZ\n"
+        "2020-01-02,10,11,9,10,1000\n"
+        "2020-01-03,12,13,11,12,1100\n"
+    )
+    df = load_prices("XYZ", data_dir=tmp_path)
+    assert len(df) == 2  # neither real row dropped
+    assert df["Close"].tolist() == [10.0, 12.0]
+
+
+def test_csv_with_index_row_whitespace_and_nan(tmp_path):
+    (tmp_path / "abc_stock_data.csv").write_text(
+        "Price ,Close ,High ,Low ,Open ,Volume \n"  # trailing whitespace in headers
+        "Ticker,ABC,ABC,ABC,ABC,ABC\n"
+        "Date,,,,,\n"  # spurious index-name row -> dropped
+        "2020-01-06,12,13,11,12,1100\n"
+        "2020-01-03,10,11,9,10,1000\n"  # out of order -> sorted
+        "2020-01-07,,,,,\n"  # NaN-close row -> dropped by load_prices
+    )
+    frame = load_price_frame(tmp_path / "abc_stock_data.csv")
+    assert ("Close", "ABC") in frame.columns  # whitespace stripped
+
+    df = load_prices("abc", data_dir=tmp_path)  # case-insensitive ticker
+    assert len(df) == 2  # Date row + NaN row dropped
+    assert df.index.is_monotonic_increasing
+    assert df["Close"].tolist() == [10.0, 12.0]
+
+
+def test_empty_after_parse_raises(tmp_path):
+    (tmp_path / "empty_stock_data.csv").write_text(
+        "Price,Close,High,Low,Open,Volume\nTicker,E,E,E,E,E\nDate,,,,,\n"
+    )
+    with pytest.raises(ValueError):
+        load_price_frame(tmp_path / "empty_stock_data.csv")

--- a/tests/test_lstm_smoke.py
+++ b/tests/test_lstm_smoke.py
@@ -1,0 +1,48 @@
+"""End-to-end smoke test of the training path (tiny data, 1 epoch).
+
+Imports TensorFlow, so it's a little slow; kept minimal. Run just this file
+with: pytest tests/test_lstm_smoke.py
+"""
+
+import numpy as np
+import pandas as pd
+
+from market_intel.models.windowing import prepare_splits
+
+
+def _synthetic_frame(n=260, seed=1):
+    rng = np.random.default_rng(seed)
+    base = np.cumsum(rng.normal(0, 1, n)) + 100
+    idx = pd.date_range("2015-01-01", periods=n, freq="B")
+    return pd.DataFrame(
+        {
+            "Close": base,
+            "High": base + 1,
+            "Low": base - 1,
+            "Open": base,
+            "Volume": rng.integers(1e6, 2e6, n).astype(float),
+        },
+        index=idx,
+    )
+
+
+def test_train_evaluate_runs():
+    from market_intel.models.lstm import train_evaluate
+
+    df = _synthetic_frame(260)
+    split = prepare_splits(df, time_step=20)
+    result = train_evaluate(split, epochs=1, batch_size=16, verbose=0)
+
+    assert "test_rmse" in result.metrics
+    assert np.isfinite(result.metrics["test_rmse"])
+    assert len(result.y_test_pred) == len(result.y_test_actual) > 0
+    assert len(result.test_index) == len(result.y_test_pred)
+
+
+def test_walk_forward_runs():
+    from market_intel.models.lstm import walk_forward_eval
+
+    df = _synthetic_frame(300)
+    wf = walk_forward_eval(df, time_step=20, n_splits=2, epochs=1)
+    assert wf["folds"]
+    assert np.isfinite(wf["mean_rmse"])

--- a/tests/test_windowing.py
+++ b/tests/test_windowing.py
@@ -1,0 +1,186 @@
+"""Regression tests for the leakage fix — the core correctness guarantee.
+
+These are written to FAIL if anyone reintroduces a leak: full-dataset feature
+*or* target scaling, pre-target-row windowing (off-by-one), or cross-fold
+leakage in walk-forward. TensorFlow-free, so they run fast.
+"""
+
+import numpy as np
+import pandas as pd
+import pytest
+
+from market_intel.models.windowing import (
+    DEFAULT_FIELDS,
+    chronological_split_indices,
+    prepare_splits,
+    walk_forward_splits,
+)
+
+FIELDS = list(DEFAULT_FIELDS)
+
+
+def _synthetic_frame(n=500, seed=0):
+    rng = np.random.default_rng(seed)
+    base = np.cumsum(rng.normal(0, 1, n)) + 100
+    idx = pd.date_range("2015-01-01", periods=n, freq="B")
+    return pd.DataFrame(
+        {
+            "Close": base,
+            "High": base + rng.uniform(0, 2, n),
+            "Low": base - rng.uniform(0, 2, n),
+            "Open": base + rng.normal(0, 0.5, n),
+            "Volume": rng.integers(1e6, 5e6, n).astype(float),
+        },
+        index=idx,
+    )
+
+
+def _ramp_frame(n=500):
+    """Strictly increasing — global max is guaranteed to land in the test slice."""
+    idx = pd.date_range("2015-01-01", periods=n, freq="B")
+    ramp = np.arange(n, dtype="float64")
+    return pd.DataFrame(
+        {"Close": ramp, "High": ramp + 1, "Low": ramp - 1, "Open": ramp, "Volume": ramp + 10},
+        index=idx,
+    )
+
+
+# --- split index math ---
+
+
+def test_split_indices():
+    assert chronological_split_indices(1000, 0.7, 0.15) == (700, 850)
+
+
+@pytest.mark.parametrize(
+    "train_frac,val_frac",
+    [(0.0, 0.1), (1.0, 0.0), (0.7, 0.3), (0.7, 0.35), (-0.1, 0.1), (0.5, -0.1)],
+)
+def test_split_indices_invalid_fracs(train_frac, val_frac):
+    with pytest.raises(ValueError):
+        chronological_split_indices(1000, train_frac, val_frac)
+
+
+# --- boundary / coverage ---
+
+
+def test_no_target_crosses_split_boundary():
+    """Train targets in train; val in val; test in test — no leakage."""
+    df = _synthetic_frame(500)
+    s = prepare_splits(df, time_step=60)
+
+    assert s.train_pos.min() == s.time_step  # full look-back exists for the first window
+    assert s.train_pos.max() < s.train_end
+    assert s.val_pos.min() >= s.train_end and s.val_pos.max() < s.val_end
+    assert s.test_pos.min() >= s.val_end and s.test_pos.max() < len(df)
+
+    # every valid target row [time_step, n) is windowed exactly once, no gaps
+    all_pos = np.concatenate([s.train_pos, s.val_pos, s.test_pos])
+    np.testing.assert_array_equal(np.sort(all_pos), np.arange(s.time_step, len(df)))
+
+
+# --- the central no-leakage claim: windows are strictly causal ---
+
+
+def test_windows_exclude_target_and_future_rows():
+    """X[k] must be exactly the `time_step` rows BEFORE its target (not incl. it)."""
+    df = _synthetic_frame(300)
+    s = prepare_splits(df, time_step=30)
+    feat_scaled = s.feature_scaler.transform(df[FIELDS].to_numpy(dtype="float64"))
+
+    for X, pos in ((s.X_train, s.train_pos), (s.X_test, s.test_pos)):
+        i = int(pos[0])
+        assert np.allclose(X[0], feat_scaled[i - s.time_step : i])  # exact window contents
+        assert np.allclose(X[0][-1], feat_scaled[i - 1])  # last row is i-1 ...
+        assert not np.allclose(X[0][-1], feat_scaled[i])  # ... NOT the target row i
+
+
+def test_target_value_alignment():
+    df = _synthetic_frame(300)
+    s = prepare_splits(df, time_step=30)
+    target_scaled = s.target_scaler.transform(df[["Close"]].to_numpy(dtype="float64")).ravel()
+    i = int(s.test_pos[0])
+    assert np.isclose(s.y_test[0], target_scaled[i])
+
+
+# --- scalers fit on train only (BOTH of them) ---
+
+
+def test_scalers_fit_on_train_only():
+    """Feature AND target scalers must reflect train-slice stats, not the full set.
+
+    The ramp guarantees the global max is in the held-out test slice, so a leaked
+    (full-fit) scaler would have data_max_ == global max and fail these asserts.
+    """
+    df = _ramp_frame(500)
+    s = prepare_splits(df, time_step=60)
+    values = df[FIELDS].to_numpy(dtype="float64")
+
+    assert np.allclose(s.feature_scaler.data_max_, values[: s.train_end].max(axis=0))
+    assert not np.allclose(s.feature_scaler.data_max_, values.max(axis=0))
+
+    assert np.allclose(s.target_scaler.data_max_, values[: s.train_end, 0].max())
+    assert not np.allclose(s.target_scaler.data_max_, values[:, 0].max())
+
+
+# --- shapes & guards ---
+
+
+def test_shapes_consistent():
+    df = _synthetic_frame(400)
+    s = prepare_splits(df, time_step=40)
+    assert s.X_train.shape[0] == len(s.y_train) == len(s.train_pos)
+    assert s.X_test.shape[1:] == (40, len(FIELDS))
+
+
+def test_val_frac_zero():
+    df = _synthetic_frame(400)
+    s = prepare_splits(df, time_step=40, train_frac=0.85, val_frac=0.0)
+    assert s.X_val.shape == (0, 40, len(FIELDS))
+    assert len(s.val_pos) == 0
+    assert s.train_end == s.val_end
+
+
+def test_too_little_data_raises():
+    with pytest.raises(ValueError):
+        prepare_splits(_synthetic_frame(50), time_step=60)
+
+
+def test_train_slice_too_small_raises():
+    # enough total rows, but the train fraction is too small for a full window
+    with pytest.raises(ValueError, match="train slice"):
+        prepare_splits(_synthetic_frame(200), time_step=60, train_frac=0.2)
+
+
+def test_target_col_not_in_features_raises():
+    with pytest.raises(ValueError):
+        prepare_splits(_synthetic_frame(300), feature_cols=("High", "Low"), target_col="Close")
+
+
+# --- walk-forward CV is leakage-free (the path that previously had no asserts) ---
+
+
+def test_walk_forward_scalers_fit_on_train_only():
+    df = _ramp_frame(600)
+    folds = walk_forward_splits(df, time_step=30, n_splits=4)
+    assert folds
+    values = df[FIELDS].to_numpy(dtype="float64")
+    for f in folds:
+        assert np.allclose(f.feature_scaler.data_max_, values[: f.train_end].max(axis=0))
+        assert np.allclose(f.target_scaler.data_max_, values[: f.train_end, 0].max())
+    # a fold that doesn't see the whole series proves it isn't a full-data fit
+    assert not np.allclose(folds[0].feature_scaler.data_max_, values.max(axis=0))
+
+
+def test_walk_forward_folds_causal():
+    df = _synthetic_frame(400)
+    folds = walk_forward_splits(df, time_step=20, n_splits=4)
+    assert folds
+    values = df[FIELDS].to_numpy(dtype="float64")
+    for f in folds:
+        # test targets are exactly the rows [train_end, stop) — contiguous, forward
+        assert len(f.y_test) == f.stop - f.train_end
+        feat_scaled = f.feature_scaler.transform(values)
+        # first test window = the `time_step` rows ending just before train_end
+        assert np.allclose(f.X_test[0], feat_scaled[f.train_end - 20 : f.train_end])
+        assert np.allclose(f.X_test[0][-1], feat_scaled[f.train_end - 1])


### PR DESCRIPTION
Restructures the single-script prototype into a tested package and fixes the core ML-correctness bug. First step of the [vision & roadmap](docs/VISION_AND_ROADMAP.md).

## Highlights
- **Fixes LSTM data leakage** (the #1 correctness issue): split chronologically first → fit feature+target scalers on the **train slice only** → strictly-causal windows; adds walk-forward (TimeSeriesSplit) CV + early stopping. AAPL test RMSE: leaky 30.32 → honest 12.55. Locked by `tests/test_windowing.py` (verified by a 3-lens adversarial review — no leakage found).
- **Format-agnostic price loader** (single- and multi-ticker yfinance CSVs); fixes the triple-`__main__` bug in the fetcher.
- Package layout `src/market_intel/{config,data,models}` with thin CLIs (preserves `python src/multi_feature_model.py AAPL`).
- Typed config (pydantic-settings) + `.env.example`; fixed `requirements.txt` (+ tensorflow/sklearn/matplotlib) + `requirements-dev.txt` + `pyproject.toml`.
- `docker-compose.yml`: `pgvector/pgvector:pg17` + Redis (localhost-only).
- 30 tests incl. strict leakage regressions; ruff/black clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)