### PR TITLE
Phase 2 (1/n) — FastAPI dashboard API + dark terminal UI

### DIFF
--- a/docs/VISION_AND_ROADMAP.md
+++ b/docs/VISION_AND_ROADMAP.md
@@ -228,11 +228,14 @@ Estimates assume solo, part-time effort. Each phase ends in something usable.
 
 **Done when:** scheduled jobs keep prices, macro, and global news flowing into Postgres unattended, with validation gates and off-box backups.
 
-### Phase 2 — Dashboard MVP _(~3–4 weeks)_
+### Phase 2 — Dashboard MVP _(~3–4 weeks)_ — 🚧 **in progress**
 **Goal: see it.**
-- Stand up the UI. **Recommended:** OpenBB Workspace + FastAPI custom backend (fastest dense terminal). Alternative: a single Streamlit app.
-- Panels: candlestick + indicators (Lightweight Charts), live news feed with ticker-level sentiment, macro dashboard, **world map of GDELT events** (Leaflet).
-- Live updates via **FastAPI WebSockets/SSE** from the worker; Redis caching for hot reads.
+- ✅ **FastAPI JSON API** (`market_intel/api`): frontend-agnostic endpoints over everything ingested — `/api/prices/{symbol}`, `/api/macro/{id}`, `/api/news/recent`, `/api/news/search` (keyword + semantic), `/api/filings/{ticker}`, `/api/health`. Test-injectable session factory; 10 tests via FastAPI TestClient. CLI `python src/serve.py`.
+- ✅ **Self-contained dark terminal dashboard** (`api/static/index.html`, no build step): candlestick price chart (TradingView Lightweight Charts), live GDELT news feed with keyword/semantic search, macro line chart, filings list. Verified end-to-end against real Postgres (500 price bars + 1000 EDGAR filings served).
+- ⬜ **World map of GDELT events** (Leaflet) — uses article `source_country`/geo.
+- ⬜ Ticker-level sentiment on the news feed; technical indicators on the chart.
+- ⬜ Live updates via **FastAPI WebSockets/SSE** + Redis caching (currently fetch-on-load).
+- ⬜ (Optional) OpenBB Workspace widgets pointed at the same API.
 
 **Done when:** one screen shows live markets + news + macro + a world event map, auto-refreshing.
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,10 @@ include = ["market_intel*"]
 pythonpath = ["src"]
 testpaths = ["tests"]
 addopts = "-q"
+filterwarnings = [
+    # starlette TestClient warns about httpx; cosmetic, not our code.
+    "ignore:Using `httpx`",
+]
 
 [tool.ruff]
 line-length = 100
@@ -29,6 +33,10 @@ src = ["src", "tests"]
 
 [tool.ruff.lint]
 select = ["E", "F", "I", "UP", "B"]
+
+[tool.ruff.lint.flake8-bugbear]
+# FastAPI's dependency-injection markers are designed to be called in defaults.
+extend-immutable-calls = ["fastapi.Depends", "fastapi.Query"]
 
 [tool.black]
 line-length = 100

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,3 +4,4 @@
 pytest==9.0.3
 ruff==0.15.17
 black==26.5.1
+httpx==0.28.1   # FastAPI TestClient

--- a/requirements.txt
+++ b/requirements.txt
@@ -23,6 +23,10 @@ pandera==0.31.1            # dataframe validation
 APScheduler==3.11.2        # ingestion scheduling
 pgvector==0.4.2            # vector column + cosine search for news
 
+# --- API / dashboard (Phase 2) ---
+fastapi==0.137.0
+uvicorn[standard]==0.49.0
+
 # Optional: real semantic embeddings (drop-in for the hashing baseline, 384-dim).
 # Heavyweight (pulls torch); install only when you want semantic-quality search.
 # sentence-transformers>=3.0

--- a/src/market_intel/api/__init__.py
+++ b/src/market_intel/api/__init__.py
@@ -1,0 +1,11 @@
+"""HTTP API + dashboard.
+
+``create_app`` builds a FastAPI app that exposes the ingested data (prices,
+macro, news + search, filings) as JSON and serves a self-contained dark
+dashboard. The JSON API is frontend-agnostic — reusable by the bundled
+dashboard, OpenBB widgets, or a future React app, and later by model serving.
+"""
+
+from market_intel.api.app import create_app
+
+__all__ = ["create_app"]

--- a/src/market_intel/api/app.py
+++ b/src/market_intel/api/app.py
@@ -1,0 +1,147 @@
+"""FastAPI application factory and JSON routes."""
+
+from __future__ import annotations
+
+import math
+from collections.abc import Iterator
+from pathlib import Path
+
+import pandas as pd
+from fastapi import Depends, FastAPI, Query
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
+from sqlalchemy.orm import Session
+
+from market_intel.search import keyword_search, semantic_search
+from market_intel.storage.db import init_db, make_engine, make_session_factory
+from market_intel.storage.filings_repo import get_filings
+from market_intel.storage.macro_repo import get_macro
+from market_intel.storage.news_repo import get_recent_articles
+from market_intel.storage.prices_repo import get_prices
+
+STATIC_DIR = Path(__file__).parent / "static"
+
+
+def _num(value) -> float | None:
+    """Coerce to a JSON-safe number (NaN -> None)."""
+    if value is None:
+        return None
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return None
+    return None if math.isnan(f) else f
+
+
+def _price_records(df: pd.DataFrame, limit: int) -> list[dict]:
+    if limit:
+        df = df.tail(limit)
+    return [
+        {
+            "date": pd.Timestamp(ts).date().isoformat(),
+            "open": _num(row.get("Open")),
+            "high": _num(row.get("High")),
+            "low": _num(row.get("Low")),
+            "close": _num(row.get("Close")),
+            "volume": _num(row.get("Volume")),
+        }
+        for ts, row in df.iterrows()
+    ]
+
+
+def _article_record(article, score: float | None = None) -> dict:
+    record = {
+        "title": article.title,
+        "url": article.url,
+        "domain": article.domain,
+        "language": article.language,
+        "source_country": article.source_country,
+        "seen_date": article.seen_date.isoformat() if article.seen_date else None,
+    }
+    if score is not None:
+        record["score"] = round(float(score), 4)
+    return record
+
+
+def _default_session_factory():
+    engine = make_engine()
+    init_db(engine)
+    return make_session_factory(engine)
+
+
+def create_app(session_factory=None) -> FastAPI:
+    """Build the API. Pass ``session_factory`` (e.g. a SQLite one) for tests."""
+    sf = session_factory or _default_session_factory()
+    app = FastAPI(title="Market Intelligence Terminal", version="0.1.0")
+
+    def get_session() -> Iterator[Session]:
+        with sf() as session:
+            yield session
+
+    @app.get("/api/health")
+    def health() -> dict:
+        return {"status": "ok"}
+
+    @app.get("/api/prices/{symbol}")
+    def prices(
+        symbol: str,
+        limit: int = Query(500, ge=0, le=10000),
+        session: Session = Depends(get_session),
+    ) -> list[dict]:
+        return _price_records(get_prices(session, symbol.upper()), limit)
+
+    @app.get("/api/macro/{series_id}")
+    def macro(
+        series_id: str,
+        limit: int = Query(2000, ge=0, le=20000),
+        session: Session = Depends(get_session),
+    ) -> list[dict]:
+        df = get_macro(session, series_id.upper())
+        if limit:
+            df = df.tail(limit)
+        return [
+            {"date": pd.Timestamp(ts).date().isoformat(), "value": _num(row["value"])}
+            for ts, row in df.iterrows()
+        ]
+
+    @app.get("/api/news/recent")
+    def news_recent(
+        limit: int = Query(50, ge=1, le=500),
+        session: Session = Depends(get_session),
+    ) -> list[dict]:
+        return [_article_record(a) for a in get_recent_articles(session, limit=limit)]
+
+    @app.get("/api/news/search")
+    def news_search(
+        q: str,
+        semantic: bool = False,
+        limit: int = Query(20, ge=1, le=200),
+        session: Session = Depends(get_session),
+    ) -> list[dict]:
+        if semantic:
+            return [_article_record(a, s) for a, s in semantic_search(session, q, limit=limit)]
+        return [_article_record(a) for a in keyword_search(session, q, limit=limit)]
+
+    @app.get("/api/filings/{ticker}")
+    def filings(
+        ticker: str,
+        limit: int = Query(50, ge=1, le=500),
+        session: Session = Depends(get_session),
+    ) -> list[dict]:
+        return [
+            {
+                "form": f.form,
+                "filing_date": f.filing_date.isoformat() if f.filing_date else None,
+                "accession_no": f.accession_no,
+                "primary_doc": f.primary_doc,
+                "cik": f.cik,
+            }
+            for f in get_filings(session, ticker, limit=limit)
+        ]
+
+    @app.get("/")
+    def index() -> FileResponse:
+        return FileResponse(STATIC_DIR / "index.html")
+
+    app.mount("/static", StaticFiles(directory=STATIC_DIR), name="static")
+    return app

--- a/src/market_intel/api/static/index.html
+++ b/src/market_intel/api/static/index.html
@@ -1,0 +1,203 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Market Intelligence Terminal</title>
+    <script src="https://unpkg.com/lightweight-charts@4.2.0/dist/lightweight-charts.standalone.production.js"></script>
+    <style>
+      :root {
+        --bg: #0a0e14; --panel: #11161f; --border: #1f2733;
+        --fg: #c7d0db; --muted: #6b7689; --accent: #f5a623; --green: #26a69a; --red: #ef5350;
+      }
+      * { box-sizing: border-box; }
+      body {
+        margin: 0; background: var(--bg); color: var(--fg);
+        font-family: ui-monospace, "SF Mono", Menlo, Consolas, monospace; font-size: 13px;
+      }
+      header {
+        display: flex; align-items: center; gap: 16px; padding: 10px 16px;
+        border-bottom: 1px solid var(--border); background: var(--panel);
+      }
+      header h1 { font-size: 14px; letter-spacing: 2px; margin: 0; color: var(--accent); }
+      header .spacer { flex: 1; }
+      input, button, label { font-family: inherit; font-size: 12px; }
+      input[type="text"] {
+        background: #0a0e14; color: var(--fg); border: 1px solid var(--border);
+        padding: 5px 8px; border-radius: 3px; outline: none;
+      }
+      input[type="text"]:focus { border-color: var(--accent); }
+      button {
+        background: #1a2230; color: var(--fg); border: 1px solid var(--border);
+        padding: 5px 12px; border-radius: 3px; cursor: pointer;
+      }
+      button:hover { border-color: var(--accent); color: var(--accent); }
+      .grid {
+        display: grid; grid-template-columns: 2fr 1fr; grid-template-rows: 1.4fr 1fr;
+        gap: 8px; padding: 8px; height: calc(100vh - 53px);
+      }
+      .panel {
+        background: var(--panel); border: 1px solid var(--border); border-radius: 4px;
+        display: flex; flex-direction: column; overflow: hidden;
+      }
+      .panel h2 {
+        font-size: 11px; letter-spacing: 1px; color: var(--muted); margin: 0;
+        padding: 7px 10px; border-bottom: 1px solid var(--border); text-transform: uppercase;
+        display: flex; align-items: center; gap: 8px;
+      }
+      .panel h2 .tag { color: var(--accent); }
+      .panel .body { flex: 1; overflow: auto; position: relative; }
+      .chart { position: absolute; inset: 0; }
+      #news { grid-row: span 2; }
+      .feed-controls { display: flex; gap: 6px; padding: 6px 8px; border-bottom: 1px solid var(--border); }
+      .feed-controls input { flex: 1; }
+      .feed-controls label { color: var(--muted); display: flex; align-items: center; gap: 4px; }
+      ul { list-style: none; margin: 0; padding: 0; }
+      .news-item { padding: 8px 10px; border-bottom: 1px solid var(--border); }
+      .news-item a { color: var(--fg); text-decoration: none; }
+      .news-item a:hover { color: var(--accent); }
+      .news-meta { color: var(--muted); font-size: 11px; margin-top: 3px; display: flex; gap: 8px; flex-wrap: wrap; }
+      .news-meta .score { color: var(--green); }
+      .filing { padding: 6px 10px; border-bottom: 1px solid var(--border); display: flex; gap: 10px; }
+      .filing .form { color: var(--accent); min-width: 56px; }
+      .filing .date { color: var(--muted); }
+      .empty { color: var(--muted); padding: 14px; }
+    </style>
+  </head>
+  <body>
+    <header>
+      <h1>◇ MARKET INTELLIGENCE TERMINAL</h1>
+      <input id="symbol" type="text" value="AAPL" size="8" />
+      <button onclick="loadSymbol()">LOAD</button>
+      <input id="macroId" type="text" value="GDP" size="10" title="FRED series id" />
+      <button onclick="loadMacro()">MACRO</button>
+      <span class="spacer"></span>
+      <span id="status" style="color: var(--muted)"></span>
+    </header>
+
+    <div class="grid">
+      <div class="panel">
+        <h2>Price <span class="tag" id="priceSym">AAPL</span></h2>
+        <div class="body"><div id="priceChart" class="chart"></div></div>
+      </div>
+
+      <div class="panel" id="news">
+        <h2>Global News <span class="tag">GDELT</span></h2>
+        <div class="feed-controls">
+          <input id="q" type="text" placeholder="search…" onkeydown="if(event.key==='Enter')searchNews()" />
+          <label><input type="checkbox" id="semantic" /> semantic</label>
+          <button onclick="searchNews()">GO</button>
+          <button onclick="loadNews()">↺</button>
+        </div>
+        <div class="body"><ul id="newsList"></ul></div>
+      </div>
+
+      <div class="panel">
+        <h2>Macro <span class="tag" id="macroLabel">GDP</span></h2>
+        <div class="body"><div id="macroChart" class="chart"></div></div>
+      </div>
+
+      <div class="panel">
+        <h2>Filings <span class="tag" id="filingsSym">AAPL</span></h2>
+        <div class="body"><ul id="filingsList"></ul></div>
+      </div>
+    </div>
+
+    <script>
+      const setStatus = (m) => (document.getElementById("status").textContent = m);
+      const chartOpts = {
+        layout: { background: { color: "transparent" }, textColor: "#6b7689" },
+        grid: { vertLines: { color: "#1f2733" }, horzLines: { color: "#1f2733" } },
+        rightPriceScale: { borderColor: "#1f2733" },
+        timeScale: { borderColor: "#1f2733" },
+        autoSize: true,
+      };
+
+      const priceChart = LightweightCharts.createChart(document.getElementById("priceChart"), chartOpts);
+      const candles = priceChart.addCandlestickSeries({
+        upColor: "#26a69a", downColor: "#ef5350", borderVisible: false,
+        wickUpColor: "#26a69a", wickDownColor: "#ef5350",
+      });
+      const macroChart = LightweightCharts.createChart(document.getElementById("macroChart"), chartOpts);
+      const macroLine = macroChart.addLineSeries({ color: "#f5a623", lineWidth: 2 });
+
+      async function getJSON(url) {
+        const r = await fetch(url);
+        if (!r.ok) throw new Error(r.status + " " + url);
+        return r.json();
+      }
+
+      async function loadPrices(sym) {
+        document.getElementById("priceSym").textContent = sym;
+        try {
+          const rows = await getJSON(`/api/prices/${sym}?limit=600`);
+          const data = rows.filter((r) => r.close != null).map((r) => ({
+            time: r.date, open: r.open, high: r.high, low: r.low, close: r.close,
+          }));
+          candles.setData(data);
+          priceChart.timeScale().fitContent();
+          setStatus(data.length ? `${sym}: ${data.length} bars` : `${sym}: no data — ingest first`);
+        } catch (e) { setStatus("price error: " + e.message); }
+      }
+
+      async function loadMacro() {
+        const id = document.getElementById("macroId").value.trim().toUpperCase() || "GDP";
+        document.getElementById("macroLabel").textContent = id;
+        try {
+          const rows = await getJSON(`/api/macro/${id}?limit=2000`);
+          macroLine.setData(rows.filter((r) => r.value != null).map((r) => ({ time: r.date, value: r.value })));
+          macroChart.timeScale().fitContent();
+        } catch (e) { setStatus("macro error: " + e.message); }
+      }
+
+      function renderNews(items) {
+        const ul = document.getElementById("newsList");
+        if (!items.length) { ul.innerHTML = '<li class="empty">No articles — run the GDELT ingestor.</li>'; return; }
+        ul.innerHTML = items.map((a) => `
+          <li class="news-item">
+            <a href="${a.url}" target="_blank" rel="noopener">${escapeHtml(a.title)}</a>
+            <div class="news-meta">
+              <span>${a.domain || ""}</span>
+              <span>${a.source_country || ""}</span>
+              <span>${a.seen_date ? a.seen_date.replace("T", " ").slice(0, 16) : ""}</span>
+              ${a.score != null ? `<span class="score">sim ${a.score}</span>` : ""}
+            </div>
+          </li>`).join("");
+      }
+
+      async function loadNews() {
+        try { renderNews(await getJSON("/api/news/recent?limit=40")); }
+        catch (e) { setStatus("news error: " + e.message); }
+      }
+      async function searchNews() {
+        const q = document.getElementById("q").value.trim();
+        if (!q) return loadNews();
+        const semantic = document.getElementById("semantic").checked;
+        try { renderNews(await getJSON(`/api/news/search?q=${encodeURIComponent(q)}&semantic=${semantic}&limit=30`)); }
+        catch (e) { setStatus("search error: " + e.message); }
+      }
+
+      async function loadFilings(sym) {
+        document.getElementById("filingsSym").textContent = sym;
+        const ul = document.getElementById("filingsList");
+        try {
+          const rows = await getJSON(`/api/filings/${sym}?limit=40`);
+          ul.innerHTML = rows.length
+            ? rows.map((f) => `<li class="filing"><span class="form">${f.form}</span><span class="date">${f.filing_date || ""}</span><span>${f.accession_no}</span></li>`).join("")
+            : '<li class="empty">No filings — run the EDGAR ingestor.</li>';
+        } catch (e) { ul.innerHTML = '<li class="empty">filings error</li>'; }
+      }
+
+      function escapeHtml(s) {
+        return (s || "").replace(/[&<>"']/g, (c) => ({ "&": "&amp;", "<": "&lt;", ">": "&gt;", '"': "&quot;", "'": "&#39;" }[c]));
+      }
+
+      function loadSymbol() {
+        const sym = document.getElementById("symbol").value.trim().toUpperCase() || "AAPL";
+        loadPrices(sym); loadFilings(sym);
+      }
+
+      loadSymbol(); loadNews(); loadMacro();
+    </script>
+  </body>
+</html>

--- a/src/serve.py
+++ b/src/serve.py
@@ -1,0 +1,32 @@
+"""Run the dashboard + JSON API (uvicorn).
+
+Requires a running Postgres (``docker compose up -d``). Open http://127.0.0.1:8000
+
+Usage:
+    python src/serve.py
+    python src/serve.py --host 0.0.0.0 --port 8080
+"""
+
+from __future__ import annotations
+
+import argparse
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import uvicorn  # noqa: E402
+
+from market_intel.api.app import create_app  # noqa: E402
+
+
+def main(argv: list[str] | None = None) -> None:
+    p = argparse.ArgumentParser(description="Serve the market-intelligence dashboard")
+    p.add_argument("--host", default="127.0.0.1")
+    p.add_argument("--port", type=int, default=8000)
+    args = p.parse_args(argv)
+    uvicorn.run(create_app(), host=args.host, port=args.port)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -1,0 +1,102 @@
+"""API endpoints via FastAPI TestClient against a seeded SQLite DB."""
+
+import pandas as pd
+import pytest
+from fastapi.testclient import TestClient
+
+from market_intel.api.app import create_app
+from market_intel.search import embed_pending
+from market_intel.storage.db import init_db, make_engine, make_session_factory
+from market_intel.storage.filings_repo import upsert_filings
+from market_intel.storage.macro_repo import upsert_macro
+from market_intel.storage.news_repo import upsert_articles
+from market_intel.storage.prices_repo import upsert_prices
+
+
+@pytest.fixture
+def client(tmp_path):
+    engine = make_engine(f"sqlite:///{tmp_path}/api.db")
+    init_db(engine)
+    sf = make_session_factory(engine)
+
+    idx = pd.date_range("2020-01-02", periods=5, freq="B")
+    prices = pd.DataFrame(
+        {
+            "Open": [10, 11, 12, 13, 14.0],
+            "High": [11, 12, 13, 14, 15.0],
+            "Low": [9, 10, 11, 12, 13.0],
+            "Close": [10.5, 11.5, 12.5, 13.5, 14.5],
+            "Volume": [100, 110, 120, 130, 140.0],
+        },
+        index=idx,
+    )
+    macro = pd.DataFrame(
+        {"value": [100.0, 101.0, 102.0]}, index=pd.date_range("2020-01-01", periods=3, freq="MS")
+    )
+    articles = [
+        {"url_hash": "h1", "url": "u1", "title": "Oil supply disruption at remote port"},
+        {"url_hash": "h2", "url": "u2", "title": "Central bank decision on rates"},
+    ]
+    filings = [{"accession_no": "a-1", "cik": "0000320193", "ticker": "AAPL", "form": "10-K"}]
+    with sf() as s:
+        upsert_prices(s, prices, "AAPL")
+        upsert_macro(s, macro, "GDP")
+        upsert_articles(s, articles)
+        upsert_filings(s, filings)
+        embed_pending(s)
+    return TestClient(create_app(session_factory=sf))
+
+
+def test_health(client):
+    assert client.get("/api/health").json() == {"status": "ok"}
+
+
+def test_prices(client):
+    rows = client.get("/api/prices/AAPL").json()
+    assert len(rows) == 5
+    assert rows[0]["close"] == 10.5
+    assert set(rows[0]) == {"date", "open", "high", "low", "close", "volume"}
+
+
+def test_prices_limit_and_case_insensitive(client):
+    assert len(client.get("/api/prices/aapl?limit=2").json()) == 2
+
+
+def test_prices_unknown_symbol_empty(client):
+    assert client.get("/api/prices/ZZZZ").json() == []
+
+
+def test_macro(client):
+    rows = client.get("/api/macro/GDP").json()
+    assert [r["value"] for r in rows] == [100.0, 101.0, 102.0]
+
+
+def test_news_recent(client):
+    rows = client.get("/api/news/recent").json()
+    assert len(rows) == 2
+    assert "title" in rows[0] and "seen_date" in rows[0]
+
+
+def test_news_search_keyword(client):
+    rows = client.get("/api/news/search?q=oil").json()
+    assert len(rows) == 1
+    assert "Oil" in rows[0]["title"]
+
+
+def test_news_search_semantic(client):
+    rows = client.get("/api/news/search?q=oil supply shock&semantic=true").json()
+    assert rows
+    assert "score" in rows[0]
+    assert rows[0]["url"] == "u1"  # most relevant first
+
+
+def test_filings(client):
+    rows = client.get("/api/filings/AAPL").json()
+    assert rows[0]["form"] == "10-K"
+    assert rows[0]["accession_no"] == "a-1"
+
+
+def test_index_served(client):
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "MARKET INTELLIGENCE TERMINAL" in resp.text


### PR DESCRIPTION
Stacked on #6 (Phase 1). The first **visible** milestone: a dashboard over everything the ingestion backbone collects.

> **Review note:** base is `phase-1-ingestion` so this PR shows only the Phase 2 commit. Merge #5 → #6 first.

## What it adds
- **FastAPI JSON API** (`market_intel/api`) — frontend-agnostic endpoints over the whole data layer:
  - `/api/prices/{symbol}`, `/api/macro/{id}`, `/api/news/recent`, `/api/news/search` (keyword + semantic), `/api/filings/{ticker}`, `/api/health`
  - Test-injectable session factory; NaN-safe JSON serialization
- **Self-contained dark "terminal" dashboard** (`api/static/index.html`, no build step): candlestick chart (TradingView Lightweight Charts), live GDELT news feed with keyword/semantic search, macro line chart, filings list
- CLI `python src/serve.py` (uvicorn)

## Why
Phase 1 ingests market/macro/news/filings into Postgres but there was no way to *see* it. This API is also the reusable backend for any future frontend (OpenBB widgets, React) and for model serving in Phase 3.

## Verification
- 10 API tests via FastAPI `TestClient` against a seeded SQLite DB; **full suite 92 passing**, ruff/black clean
- End-to-end against a real `pgvector/pg17` container + uvicorn: health ok, **500 price bars + 1000 EDGAR filings served**, index page renders

## Deps
`fastapi`, `uvicorn[standard]` (runtime); `httpx` (dev, for TestClient). Ruff config whitelists FastAPI `Depends`/`Query` in defaults.

## Not yet (next Phase 2 increments)
World map of GDELT events (Leaflet), ticker-level sentiment, live WebSocket/SSE updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)