### PR TITLE
Phase 2 (2/n) — world event map (Leaflet) over GDELT source_country

### DIFF
--- a/docs/VISION_AND_ROADMAP.md
+++ b/docs/VISION_AND_ROADMAP.md
@@ -232,7 +232,7 @@ Estimates assume solo, part-time effort. Each phase ends in something usable.
 **Goal: see it.**
 - ✅ **FastAPI JSON API** (`market_intel/api`): frontend-agnostic endpoints over everything ingested — `/api/prices/{symbol}`, `/api/macro/{id}`, `/api/news/recent`, `/api/news/search` (keyword + semantic), `/api/filings/{ticker}`, `/api/health`. Test-injectable session factory; 10 tests via FastAPI TestClient. CLI `python src/serve.py`.
 - ✅ **Self-contained dark terminal dashboard** (`api/static/index.html`, no build step): candlestick price chart (TradingView Lightweight Charts), live GDELT news feed with keyword/semantic search, macro line chart, filings list. Verified end-to-end against real Postgres (500 price bars + 1000 EDGAR filings served).
-- ⬜ **World map of GDELT events** (Leaflet) — uses article `source_country`/geo.
+- ✅ **World map of GDELT events** (Leaflet): `/api/news/map` aggregates stored articles by `source_country` and geo-locates them to country centroids (`market_intel/geo.py`, GDELT naming quirks + aliases handled, e.g. "Slovak Republic"/"Slovakia"); the dashboard renders a dark CARTO basemap with article-count-scaled circle markers. Verified against real GDELT country names (live API call) and via TestClient.
 - ⬜ Ticker-level sentiment on the news feed; technical indicators on the chart.
 - ⬜ Live updates via **FastAPI WebSockets/SSE** + Redis caching (currently fetch-on-load).
 - ⬜ (Optional) OpenBB Workspace widgets pointed at the same API.

--- a/src/market_intel/api/app.py
+++ b/src/market_intel/api/app.py
@@ -12,11 +12,12 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
 
+from market_intel.geo import country_centroid
 from market_intel.search import keyword_search, semantic_search
 from market_intel.storage.db import init_db, make_engine, make_session_factory
 from market_intel.storage.filings_repo import get_filings
 from market_intel.storage.macro_repo import get_macro
-from market_intel.storage.news_repo import get_recent_articles
+from market_intel.storage.news_repo import country_counts, get_recent_articles
 from market_intel.storage.prices_repo import get_prices
 
 STATIC_DIR = Path(__file__).parent / "static"
@@ -121,6 +122,21 @@ def create_app(session_factory=None) -> FastAPI:
         if semantic:
             return [_article_record(a, s) for a, s in semantic_search(session, q, limit=limit)]
         return [_article_record(a) for a in keyword_search(session, q, limit=limit)]
+
+    @app.get("/api/news/map")
+    def news_map(session: Session = Depends(get_session)) -> list[dict]:
+        """Per-country article counts geo-located to country centroids.
+
+        Countries with no known centroid are skipped (can't be placed on a map).
+        """
+        out = []
+        for country, count in country_counts(session):
+            geo = country_centroid(country)
+            if geo is None:
+                continue
+            lat, lon, iso = geo
+            out.append({"country": country, "count": count, "lat": lat, "lon": lon, "iso": iso})
+        return out
 
     @app.get("/api/filings/{ticker}")
     def filings(

--- a/src/market_intel/api/static/index.html
+++ b/src/market_intel/api/static/index.html
@@ -193,10 +193,10 @@
         if (!items.length) { ul.innerHTML = '<li class="empty">No articles — run the GDELT ingestor.</li>'; return; }
         ul.innerHTML = items.map((a) => `
           <li class="news-item">
-            <a href="${a.url}" target="_blank" rel="noopener">${escapeHtml(a.title)}</a>
+            <a href="${escapeHtml(a.url)}" target="_blank" rel="noopener">${escapeHtml(a.title)}</a>
             <div class="news-meta">
-              <span>${a.domain || ""}</span>
-              <span>${a.source_country || ""}</span>
+              <span>${escapeHtml(a.domain || "")}</span>
+              <span>${escapeHtml(a.source_country || "")}</span>
               <span>${a.seen_date ? a.seen_date.replace("T", " ").slice(0, 16) : ""}</span>
               ${a.score != null ? `<span class="score">sim ${a.score}</span>` : ""}
             </div>

--- a/src/market_intel/api/static/index.html
+++ b/src/market_intel/api/static/index.html
@@ -5,6 +5,8 @@
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Market Intelligence Terminal</title>
     <script src="https://unpkg.com/lightweight-charts@4.2.0/dist/lightweight-charts.standalone.production.js"></script>
+    <link rel="stylesheet" href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css" />
+    <script src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"></script>
     <style>
       :root {
         --bg: #0a0e14; --panel: #11161f; --border: #1f2733;
@@ -33,9 +35,17 @@
       }
       button:hover { border-color: var(--accent); color: var(--accent); }
       .grid {
-        display: grid; grid-template-columns: 2fr 1fr; grid-template-rows: 1.4fr 1fr;
-        gap: 8px; padding: 8px; height: calc(100vh - 53px);
+        display: grid; gap: 8px; padding: 8px; height: calc(100vh - 53px);
+        grid-template-columns: 2fr 1fr 1fr; grid-template-rows: 1.2fr 1.2fr;
+        grid-template-areas:
+          "price   map     news"
+          "macro   filings news";
       }
+      #pricePanel { grid-area: price; }
+      #mapPanel { grid-area: map; }
+      #news { grid-area: news; }
+      #macroPanel { grid-area: macro; }
+      #filingsPanel { grid-area: filings; }
       .panel {
         background: var(--panel); border: 1px solid var(--border); border-radius: 4px;
         display: flex; flex-direction: column; overflow: hidden;
@@ -48,7 +58,6 @@
       .panel h2 .tag { color: var(--accent); }
       .panel .body { flex: 1; overflow: auto; position: relative; }
       .chart { position: absolute; inset: 0; }
-      #news { grid-row: span 2; }
       .feed-controls { display: flex; gap: 6px; padding: 6px 8px; border-bottom: 1px solid var(--border); }
       .feed-controls input { flex: 1; }
       .feed-controls label { color: var(--muted); display: flex; align-items: center; gap: 4px; }
@@ -62,6 +71,21 @@
       .filing .form { color: var(--accent); min-width: 56px; }
       .filing .date { color: var(--muted); }
       .empty { color: var(--muted); padding: 14px; }
+      /* Leaflet dark-theme overrides */
+      .leaflet-container { background: var(--bg); font-family: inherit; }
+      .leaflet-control-attribution {
+        background: rgba(10, 14, 20, 0.7) !important; color: var(--muted) !important; font-size: 10px;
+      }
+      .leaflet-control-attribution a { color: var(--muted) !important; }
+      .leaflet-bar a {
+        background: var(--panel); color: var(--fg); border-color: var(--border);
+      }
+      .leaflet-bar a:hover { background: #1a2230; color: var(--accent); }
+      .leaflet-popup-content-wrapper, .leaflet-popup-tip {
+        background: var(--panel); color: var(--fg); border: 1px solid var(--border);
+      }
+      .leaflet-popup-content { margin: 8px 10px; font-size: 12px; }
+      .leaflet-popup-content b { color: var(--accent); }
     </style>
   </head>
   <body>
@@ -76,9 +100,15 @@
     </header>
 
     <div class="grid">
-      <div class="panel">
+      <div class="panel" id="pricePanel">
         <h2>Price <span class="tag" id="priceSym">AAPL</span></h2>
         <div class="body"><div id="priceChart" class="chart"></div></div>
+      </div>
+
+      <div class="panel" id="mapPanel">
+        <h2>World Events <span class="tag">GDELT</span><span class="spacer" style="flex:1"></span>
+          <button onclick="loadMap()" title="refresh map" style="padding:1px 8px">↺</button></h2>
+        <div class="body"><div id="worldMap" class="chart"></div></div>
       </div>
 
       <div class="panel" id="news">
@@ -92,12 +122,12 @@
         <div class="body"><ul id="newsList"></ul></div>
       </div>
 
-      <div class="panel">
+      <div class="panel" id="macroPanel">
         <h2>Macro <span class="tag" id="macroLabel">GDP</span></h2>
         <div class="body"><div id="macroChart" class="chart"></div></div>
       </div>
 
-      <div class="panel">
+      <div class="panel" id="filingsPanel">
         <h2>Filings <span class="tag" id="filingsSym">AAPL</span></h2>
         <div class="body"><ul id="filingsList"></ul></div>
       </div>
@@ -120,6 +150,14 @@
       });
       const macroChart = LightweightCharts.createChart(document.getElementById("macroChart"), chartOpts);
       const macroLine = macroChart.addLineSeries({ color: "#f5a623", lineWidth: 2 });
+
+      const worldMap = L.map("worldMap", { worldCopyJump: true, minZoom: 1, maxZoom: 6, attributionControl: true }).setView([25, 10], 1);
+      L.tileLayer("https://{s}.basemaps.cartocdn.com/dark_all/{z}/{x}/{y}{r}.png", {
+        attribution: '© <a href="https://www.openstreetmap.org/copyright">OpenStreetMap</a> © <a href="https://carto.com/attributions">CARTO</a>',
+        subdomains: "abcd", maxZoom: 6,
+      }).addTo(worldMap);
+      const eventLayer = L.layerGroup().addTo(worldMap);
+      addEventListener("resize", () => worldMap.invalidateSize());
 
       async function getJSON(url) {
         const r = await fetch(url);
@@ -177,6 +215,23 @@
         catch (e) { setStatus("search error: " + e.message); }
       }
 
+      async function loadMap() {
+        try {
+          const rows = await getJSON("/api/news/map");
+          eventLayer.clearLayers();
+          const max = rows.reduce((m, r) => Math.max(m, r.count), 1);
+          for (const r of rows) {
+            const radius = 4 + 14 * Math.sqrt(r.count / max);
+            L.circleMarker([r.lat, r.lon], {
+              radius, color: "#f5a623", weight: 1, fillColor: "#f5a623", fillOpacity: 0.45,
+            })
+              .bindPopup(`<b>${escapeHtml(r.country)}</b><br>${r.count} article${r.count === 1 ? "" : "s"}`)
+              .addTo(eventLayer);
+          }
+          worldMap.invalidateSize();
+        } catch (e) { setStatus("map error: " + e.message); }
+      }
+
       async function loadFilings(sym) {
         document.getElementById("filingsSym").textContent = sym;
         const ul = document.getElementById("filingsList");
@@ -197,7 +252,7 @@
         loadPrices(sym); loadFilings(sym);
       }
 
-      loadSymbol(); loadNews(); loadMacro();
+      loadSymbol(); loadNews(); loadMacro(); loadMap();
     </script>
   </body>
 </html>

--- a/src/market_intel/geo.py
+++ b/src/market_intel/geo.py
@@ -1,0 +1,209 @@
+"""Country-name → geographic centroid lookup for the world event map.
+
+GDELT's DOC 2.0 API reports a human-readable English ``sourcecountry`` (e.g.
+``"United States"``, ``"Slovak Republic"``) but no coordinates, so to place an
+article on a map we map that name to an approximate country centroid.
+
+``_CENTROIDS`` is keyed by the lowercased country name → ``(lat, lon, iso2)``.
+``_ALIASES`` maps lowercased spelling variants (including GDELT's own quirks,
+e.g. it emits "Slovak Republic" rather than "Slovakia") to a canonical key.
+``country_centroid`` normalizes the input and resolves through both.
+"""
+
+from __future__ import annotations
+
+# Approximate country centroids (latitude, longitude, ISO 3166-1 alpha-2).
+# Keys are lowercased; coordinates are rough geographic centers — precise enough
+# to place a marker on a world map, not for navigation.
+_CENTROIDS: dict[str, tuple[float, float, str]] = {
+    # --- Americas ---
+    "united states": (39.8, -98.6, "US"),
+    "canada": (56.1, -106.3, "CA"),
+    "mexico": (23.6, -102.5, "MX"),
+    "brazil": (-14.2, -51.9, "BR"),
+    "argentina": (-38.4, -63.6, "AR"),
+    "chile": (-35.7, -71.5, "CL"),
+    "peru": (-9.2, -75.0, "PE"),
+    "colombia": (4.6, -74.3, "CO"),
+    "venezuela": (6.4, -66.6, "VE"),
+    "bolivia": (-16.3, -63.6, "BO"),
+    "ecuador": (-1.8, -78.2, "EC"),
+    "paraguay": (-23.4, -58.4, "PY"),
+    "uruguay": (-32.5, -55.8, "UY"),
+    "cuba": (21.5, -77.8, "CU"),
+    "dominican republic": (18.7, -70.2, "DO"),
+    "guatemala": (15.8, -90.2, "GT"),
+    "honduras": (15.2, -86.2, "HN"),
+    "el salvador": (13.8, -88.9, "SV"),
+    "nicaragua": (12.9, -85.2, "NI"),
+    "panama": (8.5, -80.8, "PA"),
+    "costa rica": (9.7, -83.8, "CR"),
+    "jamaica": (18.1, -77.3, "JM"),
+    "haiti": (19.1, -72.3, "HT"),
+    "trinidad and tobago": (10.7, -61.2, "TT"),
+    # --- Europe ---
+    "united kingdom": (54.0, -2.0, "GB"),
+    "ireland": (53.4, -8.2, "IE"),
+    "france": (46.2, 2.2, "FR"),
+    "germany": (51.2, 10.5, "DE"),
+    "italy": (41.9, 12.6, "IT"),
+    "spain": (40.5, -3.7, "ES"),
+    "portugal": (39.4, -8.2, "PT"),
+    "netherlands": (52.1, 5.3, "NL"),
+    "belgium": (50.5, 4.5, "BE"),
+    "switzerland": (46.8, 8.2, "CH"),
+    "austria": (47.5, 14.6, "AT"),
+    "poland": (51.9, 19.1, "PL"),
+    "ukraine": (48.4, 31.2, "UA"),
+    "sweden": (60.1, 18.6, "SE"),
+    "norway": (60.5, 8.5, "NO"),
+    "finland": (61.9, 25.7, "FI"),
+    "denmark": (56.3, 9.5, "DK"),
+    "iceland": (64.96, -19.0, "IS"),
+    "greece": (39.07, 21.8, "GR"),
+    "czech republic": (49.8, 15.5, "CZ"),
+    "slovak republic": (48.7, 19.7, "SK"),
+    "hungary": (47.2, 19.5, "HU"),
+    "romania": (45.9, 24.97, "RO"),
+    "bulgaria": (42.7, 25.5, "BG"),
+    "croatia": (45.1, 15.2, "HR"),
+    "serbia": (44.0, 21.0, "RS"),
+    "bosnia and herzegovina": (43.9, 17.7, "BA"),
+    "slovenia": (46.15, 14.99, "SI"),
+    "albania": (41.15, 20.17, "AL"),
+    "north macedonia": (41.6, 21.7, "MK"),
+    "montenegro": (42.7, 19.4, "ME"),
+    "kosovo": (42.6, 20.9, "XK"),
+    "cyprus": (35.1, 33.4, "CY"),
+    "malta": (35.9, 14.4, "MT"),
+    "luxembourg": (49.8, 6.1, "LU"),
+    "estonia": (58.6, 25.0, "EE"),
+    "latvia": (56.9, 24.6, "LV"),
+    "lithuania": (55.2, 23.9, "LT"),
+    "belarus": (53.7, 27.95, "BY"),
+    "moldova": (47.4, 28.4, "MD"),
+    "russia": (61.5, 105.3, "RU"),
+    # --- Middle East & Central Asia ---
+    "turkey": (39.0, 35.2, "TR"),
+    "israel": (31.05, 34.85, "IL"),
+    "saudi arabia": (23.9, 45.1, "SA"),
+    "united arab emirates": (23.4, 53.8, "AE"),
+    "iran": (32.4, 53.7, "IR"),
+    "iraq": (33.2, 43.7, "IQ"),
+    "syria": (34.8, 38.99, "SY"),
+    "jordan": (30.6, 36.2, "JO"),
+    "lebanon": (33.85, 35.86, "LB"),
+    "qatar": (25.35, 51.18, "QA"),
+    "kuwait": (29.3, 47.5, "KW"),
+    "bahrain": (26.0, 50.55, "BH"),
+    "oman": (21.5, 55.9, "OM"),
+    "yemen": (15.55, 48.5, "YE"),
+    "azerbaijan": (40.14, 47.58, "AZ"),
+    "armenia": (40.07, 45.0, "AM"),
+    "georgia": (42.3, 43.4, "GE"),
+    "kazakhstan": (48.0, 66.9, "KZ"),
+    "uzbekistan": (41.4, 64.6, "UZ"),
+    "turkmenistan": (38.97, 59.6, "TM"),
+    "kyrgyzstan": (41.2, 74.8, "KG"),
+    "tajikistan": (38.9, 71.3, "TJ"),
+    "afghanistan": (33.9, 67.7, "AF"),
+    # --- Asia & Oceania ---
+    "china": (35.9, 104.2, "CN"),
+    "japan": (36.2, 138.3, "JP"),
+    "south korea": (35.9, 127.8, "KR"),
+    "north korea": (40.3, 127.5, "KP"),
+    "india": (20.6, 78.96, "IN"),
+    "pakistan": (30.4, 69.3, "PK"),
+    "bangladesh": (23.7, 90.4, "BD"),
+    "sri lanka": (7.9, 80.8, "LK"),
+    "nepal": (28.4, 84.1, "NP"),
+    "bhutan": (27.5, 90.4, "BT"),
+    "maldives": (3.2, 73.2, "MV"),
+    "indonesia": (-0.8, 113.9, "ID"),
+    "malaysia": (4.2, 101.98, "MY"),
+    "thailand": (15.9, 100.99, "TH"),
+    "vietnam": (14.06, 108.3, "VN"),
+    "philippines": (12.9, 121.8, "PH"),
+    "singapore": (1.35, 103.8, "SG"),
+    "myanmar": (21.9, 95.96, "MM"),
+    "cambodia": (12.6, 104.99, "KH"),
+    "laos": (19.85, 102.5, "LA"),
+    "brunei": (4.5, 114.7, "BN"),
+    "mongolia": (46.9, 103.8, "MN"),
+    "taiwan": (23.7, 121.0, "TW"),
+    "hong kong": (22.35, 114.1, "HK"),
+    "australia": (-25.3, 133.8, "AU"),
+    "new zealand": (-40.9, 174.9, "NZ"),
+    "papua new guinea": (-6.3, 143.96, "PG"),
+    "fiji": (-17.7, 178.0, "FJ"),
+    # --- Africa ---
+    "egypt": (26.8, 30.8, "EG"),
+    "libya": (26.3, 17.2, "LY"),
+    "algeria": (28.0, 1.7, "DZ"),
+    "morocco": (31.8, -7.1, "MA"),
+    "tunisia": (33.9, 9.6, "TN"),
+    "nigeria": (9.1, 8.7, "NG"),
+    "south africa": (-30.6, 22.9, "ZA"),
+    "kenya": (0.0, 37.9, "KE"),
+    "ethiopia": (9.1, 40.5, "ET"),
+    "ghana": (7.95, -1.02, "GH"),
+    "senegal": (14.5, -14.5, "SN"),
+    "ivory coast": (7.5, -5.5, "CI"),
+    "mali": (17.6, -4.0, "ML"),
+    "cameroon": (7.4, 12.4, "CM"),
+    "democratic republic of the congo": (-4.0, 21.8, "CD"),
+    "republic of the congo": (-0.2, 15.8, "CG"),
+    "rwanda": (-1.9, 29.9, "RW"),
+    "uganda": (1.4, 32.3, "UG"),
+    "tanzania": (-6.4, 34.9, "TZ"),
+    "sudan": (12.9, 30.2, "SD"),
+    "south sudan": (6.9, 31.3, "SS"),
+    "angola": (-11.2, 17.9, "AO"),
+    "mozambique": (-18.7, 35.5, "MZ"),
+    "zimbabwe": (-19.0, 29.2, "ZW"),
+    "zambia": (-13.1, 27.8, "ZM"),
+    "botswana": (-22.3, 24.7, "BW"),
+    "namibia": (-22.96, 18.5, "NA"),
+    "madagascar": (-18.8, 47.0, "MG"),
+}
+
+# Spelling variants → canonical key. Covers GDELT's own naming quirks and common
+# alternates so a different source feed still resolves.
+_ALIASES: dict[str, str] = {
+    "united states of america": "united states",
+    "usa": "united states",
+    "us": "united states",
+    "uk": "united kingdom",
+    "great britain": "united kingdom",
+    "russian federation": "russia",
+    "slovakia": "slovak republic",
+    "czechia": "czech republic",
+    "macedonia": "north macedonia",
+    "korea, south": "south korea",
+    "korea, north": "north korea",
+    "burma": "myanmar",
+    "cote d'ivoire": "ivory coast",
+    "côte d'ivoire": "ivory coast",
+    "uae": "united arab emirates",
+    "congo (kinshasa)": "democratic republic of the congo",
+    "dr congo": "democratic republic of the congo",
+    "congo (brazzaville)": "republic of the congo",
+    "congo": "republic of the congo",
+}
+
+
+def country_centroid(name: str | None) -> tuple[float, float, str] | None:
+    """Resolve a country name to ``(lat, lon, iso2)``, or ``None`` if unknown.
+
+    Matching is case-insensitive and whitespace-tolerant, and follows aliases
+    (e.g. "Slovakia" → "Slovak Republic", "USA" → "United States").
+    """
+    if not name:
+        return None
+    key = " ".join(name.strip().lower().split())
+    if key in _CENTROIDS:
+        return _CENTROIDS[key]
+    canonical = _ALIASES.get(key)
+    if canonical:
+        return _CENTROIDS.get(canonical)
+    return None

--- a/src/market_intel/storage/news_repo.py
+++ b/src/market_intel/storage/news_repo.py
@@ -59,11 +59,13 @@ def country_counts(session: Session) -> list[tuple[str, int]]:
     on a map). Returns ``[(country, count), ...]``.
     """
     n = func.count().label("n")
-    rows = session.execute(
-        select(NewsArticle.source_country, n)
-        .where(NewsArticle.source_country.isnot(None))
-        .where(NewsArticle.source_country != "")
-        .group_by(NewsArticle.source_country)
-        .order_by(n.desc())
-    ).all()
-    return [(country, count) for country, count in rows]
+    return [
+        (country, count)
+        for country, count in session.execute(
+            select(NewsArticle.source_country, n)
+            .where(NewsArticle.source_country.isnot(None))
+            .where(NewsArticle.source_country != "")
+            .group_by(NewsArticle.source_country)
+            .order_by(n.desc())
+        ).all()
+    ]

--- a/src/market_intel/storage/news_repo.py
+++ b/src/market_intel/storage/news_repo.py
@@ -4,7 +4,7 @@ from __future__ import annotations
 
 from collections.abc import Sequence
 
-from sqlalchemy import select
+from sqlalchemy import func, select
 from sqlalchemy.orm import Session
 
 from market_intel.storage.models import NewsArticle
@@ -50,3 +50,20 @@ def get_recent_articles(session: Session, limit: int = 50) -> list[NewsArticle]:
 
 def count_articles(session: Session) -> int:
     return session.query(NewsArticle).count()
+
+
+def country_counts(session: Session) -> list[tuple[str, int]]:
+    """Article counts grouped by ``source_country``, most active first.
+
+    Rows with a NULL or empty ``source_country`` are excluded (nothing to place
+    on a map). Returns ``[(country, count), ...]``.
+    """
+    n = func.count().label("n")
+    rows = session.execute(
+        select(NewsArticle.source_country, n)
+        .where(NewsArticle.source_country.isnot(None))
+        .where(NewsArticle.source_country != "")
+        .group_by(NewsArticle.source_country)
+        .order_by(n.desc())
+    ).all()
+    return [(country, count) for country, count in rows]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -34,8 +34,18 @@ def client(tmp_path):
         {"value": [100.0, 101.0, 102.0]}, index=pd.date_range("2020-01-01", periods=3, freq="MS")
     )
     articles = [
-        {"url_hash": "h1", "url": "u1", "title": "Oil supply disruption at remote port"},
-        {"url_hash": "h2", "url": "u2", "title": "Central bank decision on rates"},
+        {
+            "url_hash": "h1",
+            "url": "u1",
+            "title": "Oil supply disruption at remote port",
+            "source_country": "United States",
+        },
+        {
+            "url_hash": "h2",
+            "url": "u2",
+            "title": "Central bank decision on rates",
+            "source_country": "United Kingdom",
+        },
     ]
     filings = [{"accession_no": "a-1", "cik": "0000320193", "ticker": "AAPL", "form": "10-K"}]
     with sf() as s:
@@ -88,6 +98,17 @@ def test_news_search_semantic(client):
     assert rows
     assert "score" in rows[0]
     assert rows[0]["url"] == "u1"  # most relevant first
+
+
+def test_news_map(client):
+    rows = client.get("/api/news/map").json()
+    by_country = {r["country"]: r for r in rows}
+    assert {"United States", "United Kingdom"} <= set(by_country)
+    us = by_country["United States"]
+    assert us["count"] == 1
+    assert us["iso"] == "US"
+    assert -90 <= us["lat"] <= 90 and -180 <= us["lon"] <= 180
+    assert set(us) == {"country", "count", "lat", "lon", "iso"}
 
 
 def test_filings(client):

--- a/tests/test_geo.py
+++ b/tests/test_geo.py
@@ -1,0 +1,38 @@
+"""Country-name → centroid resolution for the world event map."""
+
+from market_intel.geo import _CENTROIDS, country_centroid
+
+
+def test_known_country():
+    lat, lon, iso = country_centroid("United States")
+    assert iso == "US"
+    assert 24 < lat < 50 and -125 < lon < -66  # roughly within the US
+
+
+def test_case_and_whitespace_insensitive():
+    assert country_centroid("  united KINGDOM  ") == country_centroid("United Kingdom")
+
+
+def test_gdelt_naming_quirk_resolves():
+    # GDELT emits "Slovak Republic"; the alias "Slovakia" resolves to the same point.
+    assert country_centroid("Slovak Republic")[2] == "SK"
+    assert country_centroid("Slovakia") == country_centroid("Slovak Republic")
+
+
+def test_aliases():
+    assert country_centroid("USA")[2] == "US"
+    assert country_centroid("Czechia") == country_centroid("Czech Republic")
+    assert country_centroid("Burma") == country_centroid("Myanmar")
+
+
+def test_unknown_returns_none():
+    assert country_centroid("Narnia") is None
+    assert country_centroid("") is None
+    assert country_centroid(None) is None
+
+
+def test_all_centroids_are_valid_coordinates():
+    for name, (lat, lon, iso) in _CENTROIDS.items():
+        assert -90 <= lat <= 90, name
+        assert -180 <= lon <= 180, name
+        assert len(iso) == 2 and iso.isupper(), name

--- a/tests/test_news.py
+++ b/tests/test_news.py
@@ -8,7 +8,12 @@ from market_intel.ingest.news import (
     parse_gdelt_articles,
 )
 from market_intel.storage.db import init_db, make_engine, make_session_factory
-from market_intel.storage.news_repo import count_articles, get_recent_articles
+from market_intel.storage.news_repo import (
+    count_articles,
+    country_counts,
+    get_recent_articles,
+    upsert_articles,
+)
 
 PAYLOAD = {
     "articles": [
@@ -106,3 +111,17 @@ def test_ingest_gdelt_end_to_end_and_idempotent(session_factory):
         assert len(recent) == 2
         # the article with a real seen_date sorts ahead of the NULL one
         assert recent[0].url == "https://example.com/a"
+
+
+def test_country_counts_aggregates_and_excludes_blank(session_factory):
+    articles = [
+        {"url_hash": "1", "url": "u1", "title": "t1", "source_country": "Egypt"},
+        {"url_hash": "2", "url": "u2", "title": "t2", "source_country": "Egypt"},
+        {"url_hash": "3", "url": "u3", "title": "t3", "source_country": "India"},
+        {"url_hash": "4", "url": "u4", "title": "t4", "source_country": None},
+        {"url_hash": "5", "url": "u5", "title": "t5", "source_country": ""},
+    ]
+    with session_factory() as s:
+        upsert_articles(s, articles)
+        counts = country_counts(s)
+    assert counts == [("Egypt", 2), ("India", 1)]  # most active first; NULL/"" dropped


### PR DESCRIPTION
## Phase 2 (2/n) — World event map (Leaflet) over GDELT `source_country`

Implements the first remaining **Phase 2** roadmap item — a **world map of GDELT events** — which is also part of Phase 2's "Done when" criterion (*"one screen shows live markets + news + macro + a world event map"*). The "FastAPI dashboard API + dark terminal UI" item shipped in #7; this stacks the map panel on top of it.

### What it does
The dashboard gains a **dark world-event map** panel. It plots, per country, how many ingested GDELT articles originated there — circle markers sized by article count over a dark CARTO basemap, with click-through popups. This surfaces the project's "edge-of-the-world" angle: where in the world the news flow is concentrated right now.

### Research → plan
GDELT's DOC 2.0 API reports a human-readable English `sourcecountry` (verified with a **live API call**: it returns names like `United States`, `South Korea`, and quirks like **`Slovak Republic`** rather than "Slovakia", `United Arab Emirates`) but **no coordinates**. So the plan was:

1. **`src/market_intel/geo.py`** — a static country-name → `(lat, lon, iso2)` centroid table (144 countries) plus an alias map for GDELT's naming quirks and common variants (`Slovakia`→`Slovak Republic`, `USA`→`United States`, `Burma`→`Myanmar`, `Czechia`→`Czech Republic`, …). Markers-at-centroids was chosen over a heavy GeoJSON choropleth to match the repo's dependency-light, no-build-step ethos.
2. **`news_repo.country_counts()`** — `GROUP BY source_country` aggregation pushed to SQL (parameterized ORM; portable across Postgres and the SQLite test backend), excluding NULL/empty, most-active first.
3. **`/api/news/map`** endpoint — composes the repo counts with the centroid lookup, skips unmappable countries, returns `{country, count, lat, lon, iso}` (shape consistent with the other endpoints).
4. **Frontend** — Leaflet 1.9.4 + CARTO `dark_all` tiles via the same unpkg CDN convention already used for `lightweight-charts`. The grid was restructured with `grid-template-areas` to cleanly fit five panels (price, map, news, macro, filings) with the news feed spanning both rows. Popups escape country names.
5. **Tests** — `tests/test_geo.py` (resolution, aliases, case/whitespace, coordinate validity), a `country_counts` repo test (aggregation + NULL/blank exclusion), and a `/api/news/map` API test.

### Review results
- **/simplify** — applied 1 cleanup (removed a no-op unpack/repack in `country_counts`). Skipped 3 with rationale: the `loadMap` `invalidateSize()` is needed for initial-load/refresh sizing (the resize listener only covers window resize); returning `max` from the endpoint isn't worth the payload coupling; keeping the geo lookup in the endpoint (controller composes repo + geo) is the right altitude — pulling it into the storage layer would couple storage to a presentation concern, which no other repo does.
- **/code-review** (xhigh) — geo data verified programmatically (no duplicate keys, no dangling aliases, no duplicate ISO codes, all coords in range). Correctness candidates refuted: `func.count()` over a GROUP is always ≥1 and `max` defaults to 1 on empty rows (no division/NaN), `country_centroid` is None-guarded with a guaranteed 3-tuple, and blank/unmappable countries degrade gracefully (skipped). One real finding fixed (see below).
- **/security-review** — no findings at confidence ≥ 8. SQL is parameterized; `/api/news/map` exposes only aggregated country/count/coords (no URLs, no `raw` JSONB, no PII); the new Leaflet popup escapes `country` and uses `lat`/`lon` only as numeric coordinates. **Fixed during review:** `renderNews()` previously injected article `domain`, `source_country`, and `url` (href) into `innerHTML` **unescaped** (only `title` was escaped) — a latent stored-XSS sink for external GDELT data. All three now route through the existing `escapeHtml()` helper.

### Tests
`100 passed` (was 92; +8 new), `ruff` clean, `black` clean.

### Roadmap
`docs/VISION_AND_ROADMAP.md` Phase 2 updated — the world-map item is marked ✅ with a description of what shipped and how it was verified. (Live updates / auto-refresh remains the outstanding item before Phase 2 is fully "done".)

Leave for human review — **do not merge**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
