### PR TITLE
Phase 2 (3/n) — technical indicators on the price chart

### DIFF
--- a/docs/VISION_AND_ROADMAP.md
+++ b/docs/VISION_AND_ROADMAP.md
@@ -230,10 +230,11 @@ Estimates assume solo, part-time effort. Each phase ends in something usable.
 
 ### Phase 2 — Dashboard MVP _(~3–4 weeks)_ — 🚧 **in progress**
 **Goal: see it.**
-- ✅ **FastAPI JSON API** (`market_intel/api`): frontend-agnostic endpoints over everything ingested — `/api/prices/{symbol}`, `/api/macro/{id}`, `/api/news/recent`, `/api/news/search` (keyword + semantic), `/api/filings/{ticker}`, `/api/health`. Test-injectable session factory; 10 tests via FastAPI TestClient. CLI `python src/serve.py`.
+- ✅ **FastAPI JSON API** (`market_intel/api`): frontend-agnostic endpoints over everything ingested — `/api/prices/{symbol}`, `/api/indicators/{symbol}`, `/api/macro/{id}`, `/api/news/recent`, `/api/news/search` (keyword + semantic), `/api/filings/{ticker}`, `/api/health`. Test-injectable session factory; tested via FastAPI TestClient. CLI `python src/serve.py`.
 - ✅ **Self-contained dark terminal dashboard** (`api/static/index.html`, no build step): candlestick price chart (TradingView Lightweight Charts), live GDELT news feed with keyword/semantic search, macro line chart, filings list. Verified end-to-end against real Postgres (500 price bars + 1000 EDGAR filings served).
 - ⬜ **World map of GDELT events** (Leaflet) — uses article `source_country`/geo.
-- ⬜ Ticker-level sentiment on the news feed; technical indicators on the chart.
+- ✅ **Technical indicators on the price chart**: SMA 20/50, EMA, **RSI** (Wilder's smoothing), **MACD**, **Bollinger Bands** computed server-side and **causally** (`market_intel/indicators.py` — `rolling`/`ewm` only, no lookahead) → `/api/indicators/{symbol}` (date-aligned, JSON-safe NaN→null) → dashboard overlays (MA + Bollinger), a toggleable **RSI** sub-band, and a latest-value readout (MA20 / RSI / MACD). Indicators load independently of the price fetch and degrade gracefully if unavailable. Tests cover the indicator math (known values, warm-up, causality, all-gains/all-losses edges) + the endpoint.
+- ⬜ Ticker-level sentiment on the news feed — **deferred**: depends on FinBERT scoring (a Phase-3 deliverable) or a keyed sentiment API (Marketaux/Finnhub); not self-contained at this stage.
 - ⬜ Live updates via **FastAPI WebSockets/SSE** + Redis caching (currently fetch-on-load).
 - ⬜ (Optional) OpenBB Workspace widgets pointed at the same API.
 

--- a/docs/plans/technical-indicators.md
+++ b/docs/plans/technical-indicators.md
@@ -1,0 +1,80 @@
+# Plan — Technical indicators on the price chart (Phase 2)
+
+_Roadmap item (§5, Phase 2): "Ticker-level sentiment on the news feed; **technical
+indicators on the chart**." This change delivers the **technical-indicators** half._
+
+> The ticker-level **sentiment** half is intentionally deferred: it depends on
+> FinBERT scoring (an explicit Phase-3 deliverable) or a keyed external sentiment
+> API (Marketaux/Finnhub), neither of which is self-contained at this point. Technical
+> indicators compute purely from price data already in Postgres, so they ship cleanly now.
+
+## Goal
+
+Compute the standard suite of technical indicators server-side from the OHLCV bars
+already ingested, expose them over the FastAPI JSON API, and overlay them on the
+dashboard's candlestick chart — matching the existing repo → compute → API → UI pattern.
+
+## Indicators & conventions (verified against current practice)
+
+All indicators are **causal** — every value uses only the current bar and trailing
+bars (`rolling`/`ewm` never look forward), so no lookahead is introduced. Warm-up
+periods (before a window is full) yield `NaN`, serialized as JSON `null` (consistent
+with the existing `_num` NaN→None helper in `api/app.py`).
+
+Computed from the **close** series (the standard input for these indicators):
+
+| Indicator | Definition | Notes |
+|---|---|---|
+| **SMA(n)** | `close.rolling(n).mean()` | windows 20 and 50 |
+| **EMA(n)** | `close.ewm(span=n, adjust=False).mean()` | `adjust=False` = the recursive EMA charting libs use; span 20 |
+| **RSI(14)** | Wilder's smoothing: avg gain/loss via `ewm(alpha=1/period, adjust=False)`, `RSI = 100 − 100/(1+RS)` | avg_loss=0 → 100; avg_gain=0 → 0 |
+| **MACD** | `EMA(12) − EMA(26)`; signal = `EMA(macd, 9)`; hist = `macd − signal` | all `adjust=False` |
+| **Bollinger(20, 2σ)** | mid = SMA(20); upper/lower = mid ± 2·`rolling(20).std(ddof=0)` | `ddof=0` = classic (population) Bollinger std |
+
+Defaults are fixed (standard windows) to keep the surface small and avoid untrusted
+parameter parsing — the roadmap explicitly warns against over-engineering.
+
+## Backend
+
+- **`src/market_intel/indicators.py`** — flat module matching the existing
+  `search.py` / `embeddings.py` style. Pure functions `sma`, `ema`, `rsi`, `macd`,
+  `bollinger_bands` over a `pd.Series`, plus `compute_indicators(df) -> pd.DataFrame`
+  that assembles the date-indexed indicator frame from a price frame
+  (`get_prices`-shaped: DatetimeIndex + Close column).
+- **`/api/indicators/{symbol}`** in `api/app.py` — fetch prices via the existing
+  `get_prices`, compute over the **full** series, then `tail(limit)` so warm-up NaNs
+  don't eat the displayed window. Returns a list of date-aligned records
+  (`{date, sma_20, sma_50, ema_20, bb_upper, bb_mid, bb_lower, rsi_14, macd,
+  macd_signal, macd_hist}`), each numeric value JSON-safe via the existing `_num`.
+  `limit` query param mirrors `/api/prices` (default 500). Unknown symbol → `[]`.
+
+## Frontend (`api/static/index.html`)
+
+- A thin controls strip in the Price panel (styled like `.feed-controls`): toggles
+  for **MA** (SMA20+SMA50), **BB** (Bollinger bands), **RSI** (bottom sub-scale).
+- Overlay line series on the existing candlestick chart (price-unit scale): SMA20,
+  SMA50, Bollinger upper/mid/lower.
+- RSI rendered on a separate bottom price-scale within the same chart via
+  `priceScaleId` + `scaleMargins` (toggleable; nudges the candles up when shown).
+- A compact latest-value readout in the panel header (SMA20 / RSI / MACD-vs-signal)
+  so MACD is surfaced without a second cramped sub-scale.
+- `loadSymbol()` also triggers `loadIndicators(sym)`; toggles flip series `visible`.
+
+## Tests (`tests/test_indicators.py` + extend `tests/test_api.py`)
+
+- Known-value math checks: SMA/EMA on a hand-computable series; RSI bounds [0,100]
+  and the all-gains→100 / all-losses→0 edge cases; MACD = EMA12−EMA26 and hist =
+  macd−signal identities; Bollinger mid = SMA and band symmetry.
+- Warm-up rows are `NaN` (e.g. first 19 SMA20 values).
+- Causality guard: appending a future bar must not change earlier indicator values.
+- API: `/api/indicators/AAPL` returns the expected keys, JSON-safe nulls in warm-up,
+  honors `limit`, and `[]` for an unknown symbol.
+
+## Out of scope
+
+Configurable windows, ticker-level sentiment, intraday indicators, and persisting
+indicators to the DB (they're cheap to recompute on read).
+
+Sources: [ChartingLens — RSI/MACD/Bollinger guide (2026)](https://chartinglens.com/blog/rsi-macd-bollinger-bands-guide) ·
+[pandas-ta-classic](https://pypi.org/project/pandas-ta-classic/) ·
+[alpharithms — RSI in Python](https://www.alpharithms.com/relative-strength-index-rsi-in-python-470209/)

--- a/src/market_intel/api/app.py
+++ b/src/market_intel/api/app.py
@@ -12,6 +12,7 @@ from fastapi.responses import FileResponse
 from fastapi.staticfiles import StaticFiles
 from sqlalchemy.orm import Session
 
+from market_intel.indicators import compute_indicators
 from market_intel.search import keyword_search, semantic_search
 from market_intel.storage.db import init_db, make_engine, make_session_factory
 from market_intel.storage.filings_repo import get_filings
@@ -45,6 +46,16 @@ def _price_records(df: pd.DataFrame, limit: int) -> list[dict]:
             "close": _num(row.get("Close")),
             "volume": _num(row.get("Volume")),
         }
+        for ts, row in df.iterrows()
+    ]
+
+
+def _indicator_records(df: pd.DataFrame, limit: int) -> list[dict]:
+    """Date-aligned indicator rows with JSON-safe (NaN -> None) values."""
+    if limit:
+        df = df.tail(limit)
+    return [
+        {"date": pd.Timestamp(ts).date().isoformat(), **{c: _num(row[c]) for c in df.columns}}
         for ts, row in df.iterrows()
     ]
 
@@ -89,6 +100,19 @@ def create_app(session_factory=None) -> FastAPI:
         session: Session = Depends(get_session),
     ) -> list[dict]:
         return _price_records(get_prices(session, symbol.upper()), limit)
+
+    @app.get("/api/indicators/{symbol}")
+    def indicators(
+        symbol: str,
+        limit: int = Query(500, ge=0, le=10000),
+        session: Session = Depends(get_session),
+    ) -> list[dict]:
+        # Compute over the full series so warm-up NaNs don't eat the window,
+        # then trim to the trailing `limit` rows for display.
+        df = get_prices(session, symbol.upper())
+        if df.empty:
+            return []
+        return _indicator_records(compute_indicators(df), limit)
 
     @app.get("/api/macro/{series_id}")
     def macro(

--- a/src/market_intel/api/app.py
+++ b/src/market_intel/api/app.py
@@ -108,10 +108,9 @@ def create_app(session_factory=None) -> FastAPI:
         session: Session = Depends(get_session),
     ) -> list[dict]:
         # Compute over the full series so warm-up NaNs don't eat the window,
-        # then trim to the trailing `limit` rows for display.
+        # then trim to the trailing `limit` rows for display. An unknown symbol
+        # yields an empty frame -> empty indicator frame -> [].
         df = get_prices(session, symbol.upper())
-        if df.empty:
-            return []
         return _indicator_records(compute_indicators(df), limit)
 
     @app.get("/api/macro/{series_id}")

--- a/src/market_intel/api/app.py
+++ b/src/market_intel/api/app.py
@@ -24,14 +24,17 @@ STATIC_DIR = Path(__file__).parent / "static"
 
 
 def _num(value) -> float | None:
-    """Coerce to a JSON-safe number (NaN -> None)."""
+    """Coerce to a JSON-safe number (NaN/±inf -> None).
+
+    ``Infinity`` is not valid JSON, so non-finite values become ``None``.
+    """
     if value is None:
         return None
     try:
         f = float(value)
     except (TypeError, ValueError):
         return None
-    return None if math.isnan(f) else f
+    return f if math.isfinite(f) else None
 
 
 def _price_records(df: pd.DataFrame, limit: int) -> list[dict]:

--- a/src/market_intel/api/static/index.html
+++ b/src/market_intel/api/static/index.html
@@ -197,16 +197,30 @@
         });
       }
 
+      function clearIndicators() {
+        for (const key of Object.keys(ind)) ind[key].setData([]);
+        rsiSeries.setData([]);
+        // Drop any RSI-band squeeze so a cleared chart isn't left with a gap.
+        priceChart.priceScale("right").applyOptions({ scaleMargins: { top: 0.1, bottom: 0.1 } });
+      }
+
       async function loadIndicators(sym) {
+        const stats = document.getElementById("priceStats");
         try {
           const rows = await getJSON(`/api/indicators/${sym}?limit=600`);
           for (const key of Object.keys(ind)) ind[key].setData(toLine(rows, key));
           rsiSeries.setData(toLine(rows, "rsi_14"));
           const last = rows.length ? rows[rows.length - 1] : {};
-          document.getElementById("priceStats").innerHTML =
+          stats.innerHTML =
             `MA20 <b>${fmt(last.sma_20)}</b> · RSI <b>${fmt(last.rsi_14, 1)}</b> · MACD <b>${fmt(last.macd)}</b>/<b>${fmt(last.macd_signal)}</b>`;
           applyToggles();
-        } catch (e) { /* indicators are optional — leave the price chart intact */ }
+        } catch (e) {
+          // Indicators are optional. Clear stale overlays (never attribute a prior
+          // symbol's lines to this one) and signal locally — not on the shared
+          // status line that sibling loaders also write to.
+          clearIndicators();
+          stats.textContent = "indicators unavailable";
+        }
       }
 
       async function loadMacro() {

--- a/src/market_intel/api/static/index.html
+++ b/src/market_intel/api/static/index.html
@@ -162,6 +162,10 @@
         return r.json();
       }
 
+      // Records -> Lightweight-Charts line points, dropping null/warm-up values.
+      const toLine = (rows, key) =>
+        rows.filter((r) => r[key] != null).map((r) => ({ time: r.date, value: r[key] }));
+
       async function loadPrices(sym) {
         document.getElementById("priceSym").textContent = sym;
         try {
@@ -196,9 +200,8 @@
       async function loadIndicators(sym) {
         try {
           const rows = await getJSON(`/api/indicators/${sym}?limit=600`);
-          const line = (key) => rows.filter((r) => r[key] != null).map((r) => ({ time: r.date, value: r[key] }));
-          for (const key of Object.keys(ind)) ind[key].setData(line(key));
-          rsiSeries.setData(line("rsi_14"));
+          for (const key of Object.keys(ind)) ind[key].setData(toLine(rows, key));
+          rsiSeries.setData(toLine(rows, "rsi_14"));
           const last = rows.length ? rows[rows.length - 1] : {};
           document.getElementById("priceStats").innerHTML =
             `MA20 <b>${fmt(last.sma_20)}</b> · RSI <b>${fmt(last.rsi_14, 1)}</b> · MACD <b>${fmt(last.macd)}</b>/<b>${fmt(last.macd_signal)}</b>`;
@@ -211,7 +214,7 @@
         document.getElementById("macroLabel").textContent = id;
         try {
           const rows = await getJSON(`/api/macro/${id}?limit=2000`);
-          macroLine.setData(rows.filter((r) => r.value != null).map((r) => ({ time: r.date, value: r.value })));
+          macroLine.setData(toLine(rows, "value"));
           macroChart.timeScale().fitContent();
         } catch (e) { setStatus("macro error: " + e.message); }
       }

--- a/src/market_intel/api/static/index.html
+++ b/src/market_intel/api/static/index.html
@@ -62,6 +62,16 @@
       .filing .form { color: var(--accent); min-width: 56px; }
       .filing .date { color: var(--muted); }
       .empty { color: var(--muted); padding: 14px; }
+      .ind-controls {
+        display: flex; gap: 14px; align-items: center;
+        padding: 5px 10px; border-bottom: 1px solid var(--border);
+      }
+      .ind-controls label { color: var(--muted); display: flex; align-items: center; gap: 4px; cursor: pointer; }
+      .stats {
+        margin-left: auto; color: var(--muted); font-size: 11px;
+        font-weight: normal; letter-spacing: 0; text-transform: none;
+      }
+      .stats b { color: var(--fg); font-weight: normal; }
     </style>
   </head>
   <body>
@@ -77,7 +87,14 @@
 
     <div class="grid">
       <div class="panel">
-        <h2>Price <span class="tag" id="priceSym">AAPL</span></h2>
+        <h2>Price <span class="tag" id="priceSym">AAPL</span>
+          <span class="stats" id="priceStats"></span>
+        </h2>
+        <div class="ind-controls">
+          <label><input type="checkbox" id="tglMA" checked onchange="applyToggles()" /> MA 20/50</label>
+          <label><input type="checkbox" id="tglBB" checked onchange="applyToggles()" /> Bollinger</label>
+          <label><input type="checkbox" id="tglRSI" onchange="applyToggles()" /> RSI</label>
+        </div>
         <div class="body"><div id="priceChart" class="chart"></div></div>
       </div>
 
@@ -118,6 +135,24 @@
         upColor: "#26a69a", downColor: "#ef5350", borderVisible: false,
         wickUpColor: "#26a69a", wickDownColor: "#ef5350",
       });
+
+      // Technical-indicator overlays. MA/Bollinger share the price scale; RSI
+      // floats in a separate bottom band (its own price scale).
+      const overlay = (color, lineStyle = 0) =>
+        priceChart.addLineSeries({ color, lineWidth: 1, lineStyle, priceLineVisible: false, lastValueVisible: false });
+      const ind = {
+        sma_20: overlay("#29b6f6"),
+        sma_50: overlay("#ffa726"),
+        bb_upper: overlay("#6b7a99", 2),
+        bb_mid: overlay("#6b7a99"),
+        bb_lower: overlay("#6b7a99", 2),
+      };
+      const rsiSeries = priceChart.addLineSeries({
+        color: "#b388ff", lineWidth: 1, priceScaleId: "rsi",
+        priceLineVisible: false, lastValueVisible: false,
+      });
+      priceChart.priceScale("rsi").applyOptions({ scaleMargins: { top: 0.82, bottom: 0 } });
+
       const macroChart = LightweightCharts.createChart(document.getElementById("macroChart"), chartOpts);
       const macroLine = macroChart.addLineSeries({ color: "#f5a623", lineWidth: 2 });
 
@@ -138,6 +173,37 @@
           priceChart.timeScale().fitContent();
           setStatus(data.length ? `${sym}: ${data.length} bars` : `${sym}: no data — ingest first`);
         } catch (e) { setStatus("price error: " + e.message); }
+      }
+
+      const fmt = (v, d = 2) => (v == null ? "—" : v.toFixed(d));
+
+      function applyToggles() {
+        const ma = document.getElementById("tglMA").checked;
+        const bb = document.getElementById("tglBB").checked;
+        const rsiOn = document.getElementById("tglRSI").checked;
+        ind.sma_20.applyOptions({ visible: ma });
+        ind.sma_50.applyOptions({ visible: ma });
+        ind.bb_upper.applyOptions({ visible: bb });
+        ind.bb_mid.applyOptions({ visible: bb });
+        ind.bb_lower.applyOptions({ visible: bb });
+        rsiSeries.applyOptions({ visible: rsiOn });
+        // Squeeze the candles up to make room for the RSI band when shown.
+        priceChart.priceScale("right").applyOptions({
+          scaleMargins: rsiOn ? { top: 0.06, bottom: 0.24 } : { top: 0.1, bottom: 0.1 },
+        });
+      }
+
+      async function loadIndicators(sym) {
+        try {
+          const rows = await getJSON(`/api/indicators/${sym}?limit=600`);
+          const line = (key) => rows.filter((r) => r[key] != null).map((r) => ({ time: r.date, value: r[key] }));
+          for (const key of Object.keys(ind)) ind[key].setData(line(key));
+          rsiSeries.setData(line("rsi_14"));
+          const last = rows.length ? rows[rows.length - 1] : {};
+          document.getElementById("priceStats").innerHTML =
+            `MA20 <b>${fmt(last.sma_20)}</b> · RSI <b>${fmt(last.rsi_14, 1)}</b> · MACD <b>${fmt(last.macd)}</b>/<b>${fmt(last.macd_signal)}</b>`;
+          applyToggles();
+        } catch (e) { /* indicators are optional — leave the price chart intact */ }
       }
 
       async function loadMacro() {
@@ -194,7 +260,7 @@
 
       function loadSymbol() {
         const sym = document.getElementById("symbol").value.trim().toUpperCase() || "AAPL";
-        loadPrices(sym); loadFilings(sym);
+        loadPrices(sym); loadIndicators(sym); loadFilings(sym);
       }
 
       loadSymbol(); loadNews(); loadMacro();

--- a/src/market_intel/indicators.py
+++ b/src/market_intel/indicators.py
@@ -1,0 +1,109 @@
+"""Technical indicators over an OHLCV price frame.
+
+All indicators are **causal**: every value depends only on the current bar and
+trailing bars (``rolling``/``ewm`` never look forward), so none introduce
+lookahead. Warm-up rows — before a window is full — are ``NaN`` and surface as
+JSON ``null`` once serialized.
+
+Conventions follow standard charting libraries:
+- EMA/MACD use ``ewm(..., adjust=False)`` (the recursive EMA traders expect).
+- RSI uses Wilder's smoothing (``ewm(alpha=1/period, adjust=False)``).
+- Bollinger Bands use the population std (``ddof=0``), the classic definition.
+"""
+
+from __future__ import annotations
+
+import pandas as pd
+
+# Standard window defaults (kept fixed — no untrusted parameter parsing).
+SMA_WINDOWS = (20, 50)
+EMA_SPAN = 20
+RSI_PERIOD = 14
+MACD_FAST = 12
+MACD_SLOW = 26
+MACD_SIGNAL = 9
+BB_WINDOW = 20
+BB_NUM_STD = 2.0
+
+
+def sma(series: pd.Series, window: int) -> pd.Series:
+    """Simple moving average over ``window`` bars."""
+    return series.rolling(window).mean()
+
+
+def ema(series: pd.Series, span: int) -> pd.Series:
+    """Exponential moving average (recursive form, ``adjust=False``)."""
+    return series.ewm(span=span, adjust=False).mean()
+
+
+def rsi(series: pd.Series, period: int = RSI_PERIOD) -> pd.Series:
+    """Relative Strength Index using Wilder's smoothing.
+
+    Returns values in [0, 100]. A flat-or-falling window (no average gain)
+    yields 0; a flat-or-rising window (no average loss) yields 100.
+    """
+    delta = series.diff()
+    gain = delta.clip(lower=0)
+    loss = -delta.clip(upper=0)
+    # Wilder's smoothing == EMA with alpha = 1/period.
+    avg_gain = gain.ewm(alpha=1 / period, adjust=False).mean()
+    avg_loss = loss.ewm(alpha=1 / period, adjust=False).mean()
+    rs = avg_gain / avg_loss
+    out = 100 - 100 / (1 + rs)
+    # avg_loss == 0 -> rs is +inf -> out is already 100; force avg_gain == 0 -> 0.
+    # Row 0 stays NaN: the first .diff() is NaN, so avg_gain[0] is NaN (not 0) and
+    # the .where below keeps it — the first bar is warm-up.
+    return out.where(avg_gain != 0, 0.0)
+
+
+def macd(
+    series: pd.Series,
+    fast: int = MACD_FAST,
+    slow: int = MACD_SLOW,
+    signal: int = MACD_SIGNAL,
+) -> pd.DataFrame:
+    """MACD line, signal line, and histogram as a 3-column frame."""
+    macd_line = ema(series, fast) - ema(series, slow)
+    signal_line = macd_line.ewm(span=signal, adjust=False).mean()
+    return pd.DataFrame(
+        {
+            "macd": macd_line,
+            "macd_signal": signal_line,
+            "macd_hist": macd_line - signal_line,
+        }
+    )
+
+
+def bollinger_bands(
+    series: pd.Series,
+    window: int = BB_WINDOW,
+    num_std: float = BB_NUM_STD,
+) -> pd.DataFrame:
+    """Bollinger Bands (upper/mid/lower) using the population std (``ddof=0``)."""
+    mid = sma(series, window)
+    std = series.rolling(window).std(ddof=0)
+    return pd.DataFrame(
+        {
+            "bb_upper": mid + num_std * std,
+            "bb_mid": mid,
+            "bb_lower": mid - num_std * std,
+        }
+    )
+
+
+def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
+    """Assemble the standard indicator suite from a price frame.
+
+    ``df`` is ``get_prices``/``load_prices``-shaped: a DatetimeIndex with a
+    ``Close`` column. Returns a frame on the same index with one column per
+    indicator series. An empty input yields an empty frame.
+    """
+    close = df["Close"].astype("float64")
+    out = pd.DataFrame(index=df.index)
+    for window in SMA_WINDOWS:
+        out[f"sma_{window}"] = sma(close, window)
+    out[f"ema_{EMA_SPAN}"] = ema(close, EMA_SPAN)
+    out = out.join(bollinger_bands(close))
+    out[f"rsi_{RSI_PERIOD}"] = rsi(close)
+    out = out.join(macd(close))
+    return out

--- a/src/market_intel/indicators.py
+++ b/src/market_intel/indicators.py
@@ -97,7 +97,11 @@ def compute_indicators(df: pd.DataFrame) -> pd.DataFrame:
     ``df`` is ``get_prices``/``load_prices``-shaped: a DatetimeIndex with a
     ``Close`` column. Returns a frame on the same index with one column per
     indicator series. An empty input yields an empty frame.
+
+    The index is sorted chronologically first: ``rolling``/``ewm`` are positional,
+    so an out-of-order frame would otherwise produce silently-wrong values.
     """
+    df = df.sort_index()
     close = df["Close"].astype("float64")
     out = pd.DataFrame(index=df.index)
     for window in SMA_WINDOWS:

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -66,6 +66,33 @@ def test_prices_unknown_symbol_empty(client):
     assert client.get("/api/prices/ZZZZ").json() == []
 
 
+def test_indicators(client):
+    rows = client.get("/api/indicators/aapl").json()
+    assert len(rows) == 5  # one row per price bar
+    assert set(rows[0]) == {
+        "date",
+        "sma_20",
+        "sma_50",
+        "ema_20",
+        "bb_upper",
+        "bb_mid",
+        "bb_lower",
+        "rsi_14",
+        "macd",
+        "macd_signal",
+        "macd_hist",
+    }
+    # Only 5 bars: SMA20 never warms up (null everywhere); EMA/RSI are defined.
+    assert all(r["sma_20"] is None for r in rows)
+    assert rows[-1]["ema_20"] is not None
+    assert rows[-1]["rsi_14"] is not None
+
+
+def test_indicators_limit_and_unknown_symbol(client):
+    assert len(client.get("/api/indicators/AAPL?limit=2").json()) == 2
+    assert client.get("/api/indicators/ZZZZ").json() == []
+
+
 def test_macro(client):
     rows = client.get("/api/macro/GDP").json()
     assert [r["value"] for r in rows] == [100.0, 101.0, 102.0]

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -4,7 +4,7 @@ import pandas as pd
 import pytest
 from fastapi.testclient import TestClient
 
-from market_intel.api.app import create_app
+from market_intel.api.app import _num, create_app
 from market_intel.search import embed_pending
 from market_intel.storage.db import init_db, make_engine, make_session_factory
 from market_intel.storage.filings_repo import upsert_filings
@@ -82,15 +82,27 @@ def test_indicators(client):
         "macd_signal",
         "macd_hist",
     }
-    # Only 5 bars: SMA20 never warms up (null everywhere); EMA/RSI are defined.
-    assert all(r["sma_20"] is None for r in rows)
+    # Only 5 bars: every window-20 column stays in warm-up (null everywhere),
+    # so they must serialize as JSON null; EMA/RSI/MACD are defined from row 0/1.
+    for col in ("sma_20", "sma_50", "bb_upper", "bb_mid", "bb_lower"):
+        assert all(r[col] is None for r in rows)
     assert rows[-1]["ema_20"] is not None
     assert rows[-1]["rsi_14"] is not None
+    assert rows[-1]["macd"] is not None
 
 
 def test_indicators_limit_and_unknown_symbol(client):
     assert len(client.get("/api/indicators/AAPL?limit=2").json()) == 2
     assert client.get("/api/indicators/ZZZZ").json() == []
+
+
+def test_num_coerces_non_finite_to_none():
+    # Infinity is not valid JSON; non-finite values must serialize as null.
+    assert _num(float("inf")) is None
+    assert _num(float("-inf")) is None
+    assert _num(float("nan")) is None
+    assert _num(None) is None
+    assert _num(1.5) == 1.5
 
 
 def test_macro(client):

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -41,6 +41,7 @@ def test_rsi_all_gains_is_100():
 
 def test_rsi_all_losses_is_0():
     out = rsi(pd.Series(np.arange(30.0, 1.0, -1.0)))
+    assert np.isnan(out.iloc[0])  # row 0 is warm-up even on a falling series
     assert np.allclose(out.iloc[1:], 0.0)
 
 
@@ -100,6 +101,13 @@ def test_compute_indicators_is_causal():
 def test_compute_indicators_empty_frame():
     empty = pd.DataFrame({"Close": []}, index=pd.DatetimeIndex([]))
     assert compute_indicators(empty).empty
+
+
+def test_compute_indicators_sorts_unsorted_input():
+    # rolling/ewm are positional: an out-of-order frame must be sorted first,
+    # else indicator values are silently wrong.
+    df = _frame(100 + np.cumsum(np.sin(np.arange(40))))
+    pd.testing.assert_frame_equal(compute_indicators(df.iloc[::-1]), compute_indicators(df))
 
 
 def test_rsi_period_changes_smoothing():

--- a/tests/test_indicators.py
+++ b/tests/test_indicators.py
@@ -1,0 +1,108 @@
+"""Math + causality checks for the technical-indicators module."""
+
+import numpy as np
+import pandas as pd
+
+from market_intel.indicators import (
+    bollinger_bands,
+    compute_indicators,
+    ema,
+    macd,
+    rsi,
+    sma,
+)
+
+
+def _frame(closes) -> pd.DataFrame:
+    idx = pd.date_range("2020-01-01", periods=len(closes), freq="B")
+    return pd.DataFrame({"Close": [float(c) for c in closes]}, index=idx)
+
+
+def test_sma_known_values_and_warmup():
+    s = pd.Series([1.0, 2, 3, 4, 5])
+    out = sma(s, 2)
+    assert np.isnan(out.iloc[0])  # warm-up
+    assert list(out.iloc[1:]) == [1.5, 2.5, 3.5, 4.5]
+
+
+def test_ema_starts_at_first_value_and_stays_bounded():
+    s = pd.Series([10.0, 20, 30, 40])
+    out = ema(s, span=3)
+    assert out.iloc[0] == 10.0  # adjust=False seeds on the first value
+    assert out.is_monotonic_increasing
+    assert out.max() <= s.max() and out.min() >= s.min()
+
+
+def test_rsi_all_gains_is_100():
+    out = rsi(pd.Series(np.arange(1.0, 30.0)))
+    assert np.isnan(out.iloc[0])
+    assert np.allclose(out.iloc[1:], 100.0)
+
+
+def test_rsi_all_losses_is_0():
+    out = rsi(pd.Series(np.arange(30.0, 1.0, -1.0)))
+    assert np.allclose(out.iloc[1:], 0.0)
+
+
+def test_rsi_stays_in_bounds():
+    rng = np.random.default_rng(0)
+    walk = 100 + np.cumsum(rng.normal(0, 1, 200))
+    out = rsi(pd.Series(walk)).dropna()
+    assert (out >= 0).all() and (out <= 100).all()
+
+
+def test_macd_identities():
+    rng = np.random.default_rng(1)
+    s = pd.Series(100 + np.cumsum(rng.normal(0, 1, 120)))
+    out = macd(s)
+    assert np.allclose(out["macd"], ema(s, 12) - ema(s, 26))
+    assert np.allclose(out["macd_hist"], out["macd"] - out["macd_signal"])
+
+
+def test_bollinger_mid_is_sma_and_bands_symmetric():
+    rng = np.random.default_rng(2)
+    s = pd.Series(100 + np.cumsum(rng.normal(0, 1, 60)))
+    bb = bollinger_bands(s, window=20, num_std=2.0)
+    assert np.allclose(bb["bb_mid"].dropna(), sma(s, 20).dropna())
+    width_up = (bb["bb_upper"] - bb["bb_mid"]).dropna()
+    width_dn = (bb["bb_mid"] - bb["bb_lower"]).dropna()
+    assert np.allclose(width_up, width_dn)
+
+
+def test_compute_indicators_columns_and_warmup():
+    df = _frame(100 + np.cumsum(np.ones(80)))
+    out = compute_indicators(df)
+    assert set(out.columns) == {
+        "sma_20",
+        "sma_50",
+        "ema_20",
+        "bb_upper",
+        "bb_mid",
+        "bb_lower",
+        "rsi_14",
+        "macd",
+        "macd_signal",
+        "macd_hist",
+    }
+    assert out["sma_20"].iloc[:19].isna().all()  # warm-up
+    assert out["sma_20"].iloc[19:].notna().all()
+    assert out.index.equals(df.index)
+
+
+def test_compute_indicators_is_causal():
+    base = _frame(100 + np.cumsum(np.sin(np.arange(60))))
+    extended = _frame(list(base["Close"]) + [999.0])  # a wild future bar
+    a = compute_indicators(base)
+    b = compute_indicators(extended).iloc[: len(base)]
+    pd.testing.assert_frame_equal(a, b)
+
+
+def test_compute_indicators_empty_frame():
+    empty = pd.DataFrame({"Close": []}, index=pd.DatetimeIndex([]))
+    assert compute_indicators(empty).empty
+
+
+def test_rsi_period_changes_smoothing():
+    # Both periods only warm up row 0, so they align — but smooth differently.
+    s = pd.Series(100 + np.cumsum(np.random.default_rng(3).normal(0, 1, 100)))
+    assert not np.allclose(rsi(s, 7).dropna(), rsi(s, 21).dropna())


### PR DESCRIPTION
## Summary

Adds the **technical-indicators** half of the Phase 2 roadmap item _"Ticker-level sentiment on the news feed; technical indicators on the chart."_ The standard indicator suite is computed **server-side** from OHLCV bars already in Postgres, exposed over the JSON API, and overlaid on the dashboard candlestick chart — following the existing repo → compute → API → UI pattern.

Indicators (all **causal** — `rolling`/`ewm` only, no lookahead; warm-up rows serialize as JSON `null`):

| Indicator | Convention |
|---|---|
| SMA 20 / 50 | `rolling(n).mean()` |
| EMA 20 | `ewm(span, adjust=False)` — recursive EMA |
| RSI 14 | Wilder's smoothing (`ewm(alpha=1/period, adjust=False)`) |
| MACD (12/26/9) | `EMA(12) − EMA(26)`, signal `EMA(·,9)`, histogram |
| Bollinger (20, 2σ) | mid = SMA(20), bands = mid ± 2·`std(ddof=0)` |

**Backend:** `market_intel/indicators.py` (pure functions + `compute_indicators`); `GET /api/indicators/{symbol}` returning date-aligned, JSON-safe records (`limit` mirrors `/api/prices`; unknown symbol → `[]`).

**Frontend:** MA + Bollinger overlays on the price scale, a toggleable RSI sub-band, a latest-value readout (MA20 / RSI / MACD), and MA/Bollinger/RSI show-hide toggles. Indicators load independently of the price fetch and degrade gracefully (stale overlays cleared on failure, with a local panel signal).

**The "sentiment" half is intentionally deferred** — it depends on FinBERT scoring (a Phase-3 deliverable) or a keyed external sentiment API (Marketaux/Finnhub), neither self-contained at this stage. The roadmap is updated to reflect this.

## Plan followed

See [`docs/plans/technical-indicators.md`](docs/plans/technical-indicators.md). Approach: research the standard formulas/conventions → pure, unit-tested indicator module → on-read API endpoint (compute over the full series, then trim to `limit` so warm-up NaNs don't eat the window) → dashboard overlays + toggles. Verified end-to-end against a seeded DB in a real browser preview (success + error paths, no console errors).

## Review results

**`/simplify`** — removed a redundant `if df.empty` guard (the compute path already yields `[]`); extracted a shared `toLine(rows, key)` JS helper reused by `loadIndicators` and `loadMacro`.

**`/code-review`** (9 finder angles + verify + sweep) — applied:
- `_num` now drops non-finite values (`NaN`/`±inf`) → `None` (`Infinity` is not valid JSON; right-altitude fix in the shared helper).
- `compute_indicators` sorts its index chronologically before computing — `rolling`/`ewm` are positional, so an out-of-order frame (e.g. a future non-DB caller) would otherwise be silently wrong.
- Dashboard clears stale overlays + the RSI band and signals locally (not on the shared status line that sibling loaders race on) when an indicators fetch fails, so a prior symbol's lines are never attributed to the current one.
- Added locking tests (sort behavior, `_num` non-finite coercion, RSI row-0 warm-up on a falling series, all window-20 columns null in warm-up).
- Intentionally **not** handled (unreachable): duplicate-timestamp index (DB `(symbol,date)` PK guarantees uniqueness) and mid-series NaN in `Close` (`Price.close` is `NOT NULL`).

**`/security-review`** — **no vulnerabilities.** `symbol` is parameterized end-to-end (no SQLi); the one `innerHTML` sink carries only `toFixed`-formatted numbers (no XSS); no user input reaches a file path or URL (no traversal/SSRF); the endpoint exposes only a transform of already-served price data. The `_num` change is a small hardening improvement.

## Tests

`107 passed` (12 new: 10 indicator-math + 2 endpoint, plus hardening). `ruff` and `black` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)